### PR TITLE
특정 메뉴의 리뷰 리스트 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
@@ -31,4 +31,15 @@ public class RestaurantReviewController {
 
         return ApiResponse.success(list, HttpStatus.OK);
     }
+
+    @GetMapping("/menus/{menuId}")
+    public ResponseEntity<ApiResponse.Success<Page<RestaurantReviewResponse.ListForMenuDTO>>> listForMenu(
+            @PathVariable Long menuId,
+            @PageableDefault Pageable pageable) {
+
+        Page<RestaurantReviewResponse.ListForMenuDTO> allListForMenu =
+                restaurantReviewService.getAllListForMenu(menuId, pageable);
+
+        return ApiResponse.success(allListForMenu, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
@@ -29,4 +29,26 @@ public class RestaurantReviewResponse {
         private Long memberId;
         private String memberName;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ListForMenuDTO {
+
+        private Long reviewId;
+        private LocalDateTime reviewCreatedAt;
+        private String reviewDescription;
+
+        private Evaluation reviewTaste;
+        private Evaluation reviewAmount;
+        private Evaluation reviewService;
+        private Evaluation reviewSpeed;
+
+        private Long restaurantId;
+        private String restaurantName;
+
+        private Long memberId;
+        private String memberName;
+    }
 }

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepository.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface RestaurantReviewCustomRepository {
 
     Page<RestaurantReviewResponse.ListDTO> findRestaurantReviewByBuildingId(Long buildingId, Pageable pageable);
+
+    Page<RestaurantReviewResponse.ListForMenuDTO> findRestaurantReviewByMenuId(Long menuId, Pageable pageable);
 }

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.livable.server.review.repository;
 
 import com.livable.server.entity.*;
 import com.livable.server.review.dto.RestaurantReviewResponse;
+import com.querydsl.core.QueryFactory;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -12,6 +13,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+
+import static com.livable.server.entity.QMember.member;
+import static com.livable.server.entity.QRestaurant.restaurant;
+import static com.livable.server.entity.QRestaurantReview.restaurantReview;
+import static com.livable.server.entity.QReview.review;
+import static com.livable.server.entity.QReviewMenuMap.reviewMenuMap;
 
 @RequiredArgsConstructor
 public class RestaurantReviewCustomRepositoryImpl implements RestaurantReviewCustomRepository {
@@ -54,6 +61,45 @@ public class RestaurantReviewCustomRepositoryImpl implements RestaurantReviewCus
                 .orderBy(review.createdAt.desc());
 
         List<RestaurantReviewResponse.ListDTO> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchJoin().fetch();
+
+        long total = query.fetchCount();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<RestaurantReviewResponse.ListForMenuDTO> findRestaurantReviewByMenuId(Long menuId, Pageable pageable) {
+
+        JPAQuery<RestaurantReviewResponse.ListForMenuDTO> query = queryFactory
+                .select(Projections.constructor(RestaurantReviewResponse.ListForMenuDTO.class,
+                        review.id,
+                        review.createdAt,
+                        review.description,
+                        restaurantReview.taste,
+                        restaurantReview.amount,
+                        restaurantReview.service,
+                        restaurantReview.speed,
+                        restaurantReview.restaurant.id,
+                        restaurant.name,
+                        review.member.id,
+                        member.name
+                ))
+                .from(review)
+                .innerJoin(restaurantReview).on(restaurantReview.id.eq(review.id))
+                .innerJoin(member).on(review.member.id.eq(member.id))
+                .innerJoin(restaurant).on(restaurantReview.restaurant.id.eq(restaurant.id))
+                .where(review.id.in(
+                        JPAExpressions
+                                .select(reviewMenuMap.review.id)
+                                .from(reviewMenuMap)
+                                .where(reviewMenuMap.menu.id.eq(menuId))
+                ))
+                .orderBy(review.createdAt.desc());
+
+        List<RestaurantReviewResponse.ListForMenuDTO> content = query
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchJoin().fetch();

--- a/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
+++ b/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
@@ -18,4 +18,9 @@ public class RestaurantReviewService {
     public Page<RestaurantReviewResponse.ListDTO> getAllList(Long buildingId, Pageable pageable) {
         return restaurantReviewRepository.findRestaurantReviewByBuildingId(buildingId, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Page<RestaurantReviewResponse.ListForMenuDTO> getAllListForMenu(Long menuId, Pageable pageable) {
+        return restaurantReviewRepository.findRestaurantReviewByMenuId(menuId, pageable);
+    }
 }

--- a/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
@@ -69,4 +69,44 @@ class RestaurantReviewControllerTest {
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.length()").value(10));
         }
     }
+
+    @Nested
+    @DisplayName("특정 메뉴에 대한 레스토랑 리뷰 리스트 컨트롤러 단위 테스트")
+    class listForMenu {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            String uri = "/api/reviews/menus/1";
+
+            List<RestaurantReviewResponse.ListForMenuDTO> mockList = List.of(
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(1L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(2L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(3L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(4L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(6L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(5L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(7L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(8L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(9L).build(),
+                    RestaurantReviewResponse.ListForMenuDTO.builder().reviewId(10L).build()
+            );
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<RestaurantReviewResponse.ListForMenuDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
+
+            Mockito.when(restaurantReviewService
+                            .getAllListForMenu(ArgumentMatchers.anyLong(), ArgumentMatchers.any(Pageable.class)))
+                    .thenReturn(mockPage);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").isArray())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.length()").value(10));
+        }
+    }
 }

--- a/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
+++ b/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
+import static com.livable.server.review.dto.RestaurantReviewResponse.*;
+
 @ExtendWith(MockitoExtension.class)
 class RestaurantReviewServiceTest {
 
@@ -38,20 +40,20 @@ class RestaurantReviewServiceTest {
             // Given
             Long buildingId = 1L;
 
-            List<RestaurantReviewResponse.ListDTO> mockList = List.of(
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(1L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(2L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(3L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(4L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(5L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(6L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(7L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(8L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(9L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(10L).build()
+            List<ListDTO> mockList = List.of(
+                    ListDTO.builder().reviewId(1L).build(),
+                    ListDTO.builder().reviewId(2L).build(),
+                    ListDTO.builder().reviewId(3L).build(),
+                    ListDTO.builder().reviewId(4L).build(),
+                    ListDTO.builder().reviewId(5L).build(),
+                    ListDTO.builder().reviewId(6L).build(),
+                    ListDTO.builder().reviewId(7L).build(),
+                    ListDTO.builder().reviewId(8L).build(),
+                    ListDTO.builder().reviewId(9L).build(),
+                    ListDTO.builder().reviewId(10L).build()
             );
             Pageable pageable = PageRequest.of(0, 10);
-            Page<RestaurantReviewResponse.ListDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
+            Page<ListDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
 
             Mockito.when(restaurantReviewRepository.findRestaurantReviewByBuildingId(
                     ArgumentMatchers.anyLong(),
@@ -59,8 +61,50 @@ class RestaurantReviewServiceTest {
             )).thenReturn(mockPage);
 
             // When
-            Page<RestaurantReviewResponse.ListDTO> actual =
+            Page<ListDTO> actual =
                     restaurantReviewService.getAllList(buildingId, pageable);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(10, actual.getSize()),
+                    () -> Assertions.assertEquals(1,actual.getTotalPages())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 메뉴에 대한 레스토랑 리뷰 리스트 서비스 단위 테스트")
+    class listForMenu {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() {
+            // Given
+            Long menuId = 1L;
+
+            List<ListForMenuDTO> mockList = List.of(
+                    ListForMenuDTO.builder().reviewId(1L).build(),
+                    ListForMenuDTO.builder().reviewId(2L).build(),
+                    ListForMenuDTO.builder().reviewId(3L).build(),
+                    ListForMenuDTO.builder().reviewId(4L).build(),
+                    ListForMenuDTO.builder().reviewId(5L).build(),
+                    ListForMenuDTO.builder().reviewId(6L).build(),
+                    ListForMenuDTO.builder().reviewId(7L).build(),
+                    ListForMenuDTO.builder().reviewId(8L).build(),
+                    ListForMenuDTO.builder().reviewId(9L).build(),
+                    ListForMenuDTO.builder().reviewId(10L).build()
+            );
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<ListForMenuDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
+
+            Mockito.when(restaurantReviewRepository.findRestaurantReviewByMenuId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(Pageable.class)
+            )).thenReturn(mockPage);
+
+            // When
+            Page<ListForMenuDTO> actual =
+                    restaurantReviewService.getAllListForMenu(menuId, pageable);
 
             // Then
             Assertions.assertAll(


### PR DESCRIPTION
메뉴id를 PathVariable로 제공받아 해당 메뉴에 대한 레스토랑 리뷰 리스트를 응답한다.
페이징의 default size 는 10 으로 지정한다.
- `GET` /api/reviews/menus/{menuId}?page={page}
- #33 

### 프로세스
- [x] 요청 URL에 PathVariable로 포함된 menu_id를 추출한다.
- [x] menu_id를 통해 menu_review_map 테이블에서 메뉴에 해당하는 review_id를 추출한다.
- [x] review_id를 통해 restaurant_review 테이블을 조회한다.
- [x] review_id를 통해 member 테이블의 멤버 이름을 조회한다.
- [x] restaurant_review 테이블을 통해 restaurant 테이블의 음식점 이름을 조회한다.

### 쿼리
```SQL
SELECT
    review.id as reivew_id,
    review.created_at as review_created_at,
    review.description as review_descriptrion,
    restaurant_review.taste as review_taste,
    restaurant_review.service as review_service,
    restaurant_review.amount as review_amount,
    restaurant_review.speed as review_speed,
    member.id as member_id,
    member.name as member_name,
    restaurant.id as restaurant_id,
    restaurant.name as restaurant_name
FROM review
INNER JOIN restaurant_review ON restaurant_review.id = review.id
INNER JOIN member ON review.member_id = member.id
INNER JOIN restaurant ON restaurant_review.restaurant_id = restaurant.id
WHERE review.id
IN (
    SELECT review_id
    FROM review_menu_map
    WHERE menu_id = 3
)
ORDER BY review.created_at DESC;
```

내가,, 마이바티스 프로젝트를 하고 있는 건가?,,
### Issue
- #26 의 이슈와 동일하게 페이징의 카운트때문에 쿼리가 한번 더 날아가는 상황
- 오류가 날만한 곳을 상세하게 파악하여 예외처리 할 것
- 이미지 파일은 나중에 처리할 것