### PR TITLE
Amazon S3 적용 및 이미지 저장 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     implementation 'com.google.zxing:core:3.5.2'
     implementation 'com.google.zxing:javase:3.5.2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/livable/server/core/config/S3Config.java
+++ b/src/main/java/com/livable/server/core/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.livable.server.core.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/livable/server/core/util/S3Uploader.java
+++ b/src/main/java/com/livable/server/core/util/S3Uploader.java
@@ -1,0 +1,75 @@
+package com.livable.server.core.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "png", "gif", "jpeg");
+    private static final String EXTENSION_SEPARATOR = ".";
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<String> saveFile(List<MultipartFile> files) throws IOException {
+
+        List<String> accessUrls = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            String accessUrl = saveFile(file);
+            accessUrls.add(accessUrl);
+        }
+        return accessUrls;
+    }
+
+    public String saveFile(MultipartFile file) throws IOException {
+
+        final String originalFileName = file.getOriginalFilename();
+        assert originalFileName != null;
+        final String fileExtension = getFileExtension(originalFileName);
+
+        validationAllowedFileExtension(fileExtension);
+        String randomFileName = generateRandomFileName(originalFileName, fileExtension);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        amazonS3.putObject(bucket, randomFileName, file.getInputStream(), metadata);
+
+        return amazonS3.getUrl(bucket, randomFileName).toString();
+    }
+
+    // 랜덤한 파일 이름을 생성하는 메서드
+    private String generateRandomFileName(String originalFileName, String fileExtension) {
+        return UUID.randomUUID() + originalFileName + EXTENSION_SEPARATOR + fileExtension;
+    }
+
+    // 파일 이름에서 파일 확장자를 추출하는 메서드
+    private String getFileExtension(String originalFileName) {
+        return originalFileName
+                .substring(originalFileName.lastIndexOf(EXTENSION_SEPARATOR) + 1)
+                .toLowerCase();
+
+    }
+
+    // 파일 확장자를 검증하는 메서드
+    private void validationAllowedFileExtension(String fileExtension) {
+        if (!ALLOWED_EXTENSIONS.contains(fileExtension)) {
+            throw new IllegalArgumentException("지원하지 않는 파일 확장자 입니다.");
+        }
+    }
+}


### PR DESCRIPTION
API 서버와 파일 서버를 합쳐서 운영하기엔 용량에 부담이 있어
S3를 이미지 파일 서버로 운영하려고 한다.
- #40 

### S3 Config
`Bucket-Name`: livable-final
`Access`: public

### Issue
- 사용부에서 IOException 처리 필요
- `S3Uploader` 의존성 주입 받고 `saveFile` 메서드 사용하시면 됩니다.
- 반환 값은 S3에 저장된 이미지에 접근 가능한 `public URL` 입니다.
- yml 파일에 설정 값 추가가 필요합니다.

resolved: #40 