### PR TITLE
달력 리뷰 상세페이지 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/review/controller/MyReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/MyReviewController.java
@@ -1,0 +1,51 @@
+package com.livable.server.review.controller;
+
+import com.livable.server.core.response.ApiResponse;
+import com.livable.server.review.dto.MyReviewResponse;
+import com.livable.server.review.service.MyReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MyReviewController {
+
+    private final MyReviewService myReviewService;
+
+    @GetMapping("/api/reviews/restaurant/{reviewId}/members")
+    public ResponseEntity<ApiResponse.Success<MyReviewResponse.DetailDTO>> getMyRestaurantReview(
+            @PathVariable Long reviewId) {
+
+        // TODO: JWT 구현완료 시 토큰으로부터 값을 꺼내올 것
+        Long memberId = 1L;
+
+        MyReviewResponse.DetailDTO myRestaurantReview = myReviewService.getMyRestaurantReview(reviewId, memberId);
+        return ApiResponse.success(myRestaurantReview, HttpStatus.OK);
+    }
+
+    @GetMapping("/api/reviews/cafeteria/{reviewId}/members")
+    public ResponseEntity<ApiResponse.Success<MyReviewResponse.DetailDTO>> getMyCafeteriaReviewDetail(
+            @PathVariable Long reviewId) {
+
+        // TODO: JWT 구현완료 시 토큰으로부터 값을 꺼내올 것
+        Long memberId = 1L;
+
+        MyReviewResponse.DetailDTO myCafeteriaReview = myReviewService.getMyCafeteriaReview(reviewId, memberId);
+        return ApiResponse.success(myCafeteriaReview, HttpStatus.OK);
+    }
+
+    @GetMapping("/api/reviews/lunchbox/{reviewId}/members")
+    public ResponseEntity<ApiResponse.Success<MyReviewResponse.DetailDTO>> getMyLunchboxReviewDetail(
+            @PathVariable Long reviewId) {
+
+        // TODO: JWT 구현완료 시 토큰으로부터 값을 꺼내올 것
+        Long memberId = 1L;
+
+        MyReviewResponse.DetailDTO myLunchBoxReview = myReviewService.getMyLunchBoxReview(reviewId, memberId);
+        return ApiResponse.success(myLunchBoxReview, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/livable/server/review/domain/MyReview.java
+++ b/src/main/java/com/livable/server/review/domain/MyReview.java
@@ -1,0 +1,53 @@
+package com.livable.server.review.domain;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.review.dto.MyReviewProjection;
+import com.livable.server.review.dto.MyReviewResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MyReview {
+
+    private final List<MyReviewProjection> reviews;
+
+    private MyReview(List<MyReviewProjection> reviews) {
+        validationReviews(reviews);
+        this.reviews = reviews;
+    }
+
+    private void validationReviews(List<MyReviewProjection> reviews) {
+        if (reviews.isEmpty()) {
+            throw new GlobalRuntimeException(MyReviewErrorCode.REVIEW_NOT_EXIST);
+        }
+    }
+
+    public static MyReview from(List<MyReviewProjection> reviews) {
+        return new MyReview(reviews);
+    }
+
+    public MyReviewResponse.DetailDTO toResponseDTO() {
+
+        MyReviewProjection myReviewDTO = this.getTopOne();
+        List<String> images = this.getImages();
+
+        return MyReviewResponse.DetailDTO.builder()
+                .reviewTitle(myReviewDTO.getReviewTitle())
+                .reviewTaste(myReviewDTO.getReviewTaste())
+                .reviewDescription(myReviewDTO.getReviewDescription())
+                .reviewCreatedAt(myReviewDTO.getReviewCreatedAt())
+                .location(myReviewDTO.getLocation())
+                .reviewImg(images)
+                .build();
+    }
+
+    private MyReviewProjection getTopOne() {
+        return reviews.get(0);
+    }
+
+    private List<String> getImages() {
+        return reviews.stream()
+                .map(MyReviewProjection::getReviewImg)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/livable/server/review/domain/MyReviewErrorCode.java
+++ b/src/main/java/com/livable/server/review/domain/MyReviewErrorCode.java
@@ -1,0 +1,17 @@
+package com.livable.server.review.domain;
+
+import com.livable.server.core.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MyReviewErrorCode implements ErrorCode {
+
+    REVIEW_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 리뷰 정보입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/livable/server/review/dto/MyReviewProjection.java
+++ b/src/main/java/com/livable/server/review/dto/MyReviewProjection.java
@@ -1,0 +1,29 @@
+package com.livable.server.review.dto;
+
+import com.livable.server.entity.Evaluation;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyReviewProjection {
+
+    private String reviewTitle;
+    private Evaluation reviewTaste;
+    private String reviewDescription;
+    private LocalDateTime reviewCreatedAt;
+    private String location;
+    private String reviewImg;
+
+    public MyReviewProjection(String reviewTitle, String reviewDescription, LocalDateTime reviewCreatedAt, String reviewImg) {
+        this.reviewTitle = reviewTitle;
+        this.reviewDescription = reviewDescription;
+        this.reviewCreatedAt = reviewCreatedAt;
+        this.reviewImg = reviewImg;
+    }
+}

--- a/src/main/java/com/livable/server/review/dto/MyReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/MyReviewResponse.java
@@ -1,0 +1,26 @@
+package com.livable.server.review.dto;
+
+import com.livable.server.entity.Evaluation;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyReviewResponse {
+
+    @Getter
+    @Builder
+    public static class DetailDTO {
+
+        private String reviewTitle;
+        private Evaluation reviewTaste;
+        private String reviewDescription;
+        private LocalDateTime reviewCreatedAt;
+        private List<String> reviewImg;
+        private String location;
+    }
+}

--- a/src/main/java/com/livable/server/review/repository/MyReviewRepository.java
+++ b/src/main/java/com/livable/server/review/repository/MyReviewRepository.java
@@ -1,0 +1,16 @@
+package com.livable.server.review.repository;
+
+import com.livable.server.review.dto.MyReviewProjection;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MyReviewRepository {
+
+    List<MyReviewProjection> findRestaurantReviewByReviewId(Long reviewId, Long memberId);
+
+    List<MyReviewProjection> findLunchBoxReviewByReviewId(Long reviewId, Long memberId);
+
+    List<MyReviewProjection> findCafeteriaReviewByReviewId(Long reviewId, Long memberId);
+}

--- a/src/main/java/com/livable/server/review/repository/MyReviewRepositoryImpl.java
+++ b/src/main/java/com/livable/server/review/repository/MyReviewRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.livable.server.review.repository;
+
+import com.livable.server.review.dto.MyReviewProjection;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.livable.server.entity.QBuilding.building;
+import static com.livable.server.entity.QCafeteriaReview.cafeteriaReview;
+import static com.livable.server.entity.QRestaurant.restaurant;
+import static com.livable.server.entity.QRestaurantReview.restaurantReview;
+import static com.livable.server.entity.QReview.review;
+import static com.livable.server.entity.QReviewImage.reviewImage;
+
+@Component
+@RequiredArgsConstructor
+public class MyReviewRepositoryImpl implements MyReviewRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<MyReviewProjection> findRestaurantReviewByReviewId(Long reviewId, Long memberId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(MyReviewProjection.class,
+                        review.selectedDishes,
+                        restaurantReview.taste,
+                        review.description,
+                        review.createdAt,
+                        restaurant.name,
+                        reviewImage.url
+                ))
+                .from(review)
+                .leftJoin(reviewImage).on(reviewImage.review.id.eq(review.id))
+                .innerJoin(restaurantReview).on(restaurantReview.id.eq(review.id))
+                .innerJoin(restaurant).on(restaurant.id.eq(restaurantReview.restaurant.id))
+                .where(review.id.eq(reviewId).and(review.member.id.eq(memberId)))
+                .fetch();
+    }
+
+    @Override
+    public List<MyReviewProjection> findLunchBoxReviewByReviewId(Long reviewId, Long memberId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(MyReviewProjection.class,
+                        review.selectedDishes,
+                        review.description,
+                        review.createdAt,
+                        reviewImage.url
+                ))
+                .from(review)
+                .leftJoin(reviewImage).on(reviewImage.review.id.eq(review.id))
+                .where(review.id.eq(reviewId).and(review.member.id.eq(memberId)))
+                .fetch();
+    }
+
+    @Override
+    public List<MyReviewProjection> findCafeteriaReviewByReviewId(Long reviewId, Long memberId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(MyReviewProjection.class,
+                        review.selectedDishes,
+                        cafeteriaReview.taste,
+                        review.description,
+                        review.createdAt,
+                        building.name,
+                        reviewImage.url
+                ))
+                .from(review)
+                .leftJoin(reviewImage).on(reviewImage.review.id.eq(review.id))
+                .innerJoin(cafeteriaReview).on(cafeteriaReview.id.eq(review.id))
+                .innerJoin(building).on(building.id.eq(cafeteriaReview.building.id))
+                .where(review.id.eq(reviewId).and(review.member.id.eq(memberId)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/livable/server/review/service/MyReviewService.java
+++ b/src/main/java/com/livable/server/review/service/MyReviewService.java
@@ -1,0 +1,47 @@
+package com.livable.server.review.service;
+
+import com.livable.server.review.domain.MyReview;
+import com.livable.server.review.dto.MyReviewProjection;
+import com.livable.server.review.dto.MyReviewResponse;
+import com.livable.server.review.repository.MyReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class MyReviewService {
+
+    private final MyReviewRepository myReviewRepository;
+
+    public MyReviewResponse.DetailDTO getMyRestaurantReview(Long reviewId, Long memberId) {
+
+        List<MyReviewProjection> myReviewProjections
+                = myReviewRepository.findRestaurantReviewByReviewId(reviewId, memberId);
+
+        return this.convertToDTO(myReviewProjections);
+    }
+
+    public MyReviewResponse.DetailDTO getMyCafeteriaReview(Long reviewId, Long memberId) {
+
+        List<MyReviewProjection> myReviewProjections
+                = myReviewRepository.findCafeteriaReviewByReviewId(reviewId, memberId);
+
+        return this.convertToDTO(myReviewProjections);
+    }
+
+    public MyReviewResponse.DetailDTO getMyLunchBoxReview(Long reviewId, Long memberId) {
+
+        List<MyReviewProjection> myReviewProjections
+                = myReviewRepository.findLunchBoxReviewByReviewId(reviewId, memberId);
+
+        return this.convertToDTO(myReviewProjections);
+    }
+
+    private MyReviewResponse.DetailDTO convertToDTO(List<MyReviewProjection> myReviewProjections) {
+
+        MyReview myReview = MyReview.from(myReviewProjections);
+        return myReview.toResponseDTO();
+    }
+}

--- a/src/test/java/com/livable/server/review/controller/MyReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/MyReviewControllerTest.java
@@ -1,0 +1,113 @@
+package com.livable.server.review.controller;
+
+import com.livable.server.review.dto.MyReviewResponse;
+import com.livable.server.review.service.MyReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(MyReviewController.class)
+class MyReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MyReviewService myReviewService;
+
+    @Nested
+    @DisplayName("나의 레스토랑 리뷰 컨트롤러 단위 테스트")
+    class MyRestaurantReview {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String uri = "/api/reviews/restaurant/1/members";
+
+            MyReviewResponse.DetailDTO mockResponse
+                    = MyReviewResponse.DetailDTO.builder().build();
+
+            Mockito.when(myReviewService.getMyRestaurantReview(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockResponse);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("나의 구내식당 리뷰 컨트롤러 단위 테스트")
+    class MyCafeteriaReview {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String uri = "/api/reviews/cafeteria/1/members";
+
+            MyReviewResponse.DetailDTO mockResponse
+                    = MyReviewResponse.DetailDTO.builder().build();
+
+            Mockito.when(myReviewService.getMyCafeteriaReview(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockResponse);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("나의 도시락 리뷰 컨트롤러 단위 테스트")
+    class MyLunchBoxReview {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String uri = "/api/reviews/lunchbox/1/members";
+
+            MyReviewResponse.DetailDTO mockResponse
+                    = MyReviewResponse.DetailDTO.builder().build();
+
+            Mockito.when(myReviewService.getMyLunchBoxReview(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockResponse);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists());
+        }
+    }
+}

--- a/src/test/java/com/livable/server/review/controller/MyReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/MyReviewControllerTest.java
@@ -32,8 +32,6 @@ class MyReviewControllerTest {
         @Test
         void success_Test() throws Exception {
             // Given
-            Long reviewId = 1L;
-            Long memberId = 1L;
             String uri = "/api/reviews/restaurant/1/members";
 
             MyReviewResponse.DetailDTO mockResponse
@@ -61,8 +59,6 @@ class MyReviewControllerTest {
         @Test
         void success_Test() throws Exception {
             // Given
-            Long reviewId = 1L;
-            Long memberId = 1L;
             String uri = "/api/reviews/cafeteria/1/members";
 
             MyReviewResponse.DetailDTO mockResponse
@@ -90,8 +86,6 @@ class MyReviewControllerTest {
         @Test
         void success_Test() throws Exception {
             // Given
-            Long reviewId = 1L;
-            Long memberId = 1L;
             String uri = "/api/reviews/lunchbox/1/members";
 
             MyReviewResponse.DetailDTO mockResponse

--- a/src/test/java/com/livable/server/review/domain/MyReviewTest.java
+++ b/src/test/java/com/livable/server/review/domain/MyReviewTest.java
@@ -39,7 +39,7 @@ class MyReviewTest {
 
             // When
             // Then
-            MyReview actual = MyReview.from(myReviewProjections);
+            MyReview.from(myReviewProjections);
         }
 
         @DisplayName("실패 - 비어있는 쿼리 결과로 생성")

--- a/src/test/java/com/livable/server/review/domain/MyReviewTest.java
+++ b/src/test/java/com/livable/server/review/domain/MyReviewTest.java
@@ -1,0 +1,134 @@
+package com.livable.server.review.domain;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.entity.Evaluation;
+import com.livable.server.review.dto.MyReviewProjection;
+import com.livable.server.review.dto.MyReviewResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("나의 리뷰 쿼리 결과 래퍼 클래스 테스트")
+class MyReviewTest {
+
+
+    @DisplayName("정적 팩토리 메서드 테스트 (생성자 및 검증 메서드 간접 테스트)")
+    @Nested
+    class StaticFactoryMethod {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() {
+            // Given
+            List<MyReviewProjection> myReviewProjections = List.of(
+                    MyReviewProjection.builder()
+                            .reviewTitle("TestTitle")
+                            .reviewDescription("TestDescription")
+                            .reviewCreatedAt(LocalDateTime.now())
+                            .reviewTaste(Evaluation.GOOD)
+                            .reviewImg("TestImage")
+                            .location("TestLocation")
+                            .build()
+            );
+
+            // When
+            // Then
+            MyReview actual = MyReview.from(myReviewProjections);
+        }
+
+        @DisplayName("실패 - 비어있는 쿼리 결과로 생성")
+        @Test
+        void failure_Test_constructedEmptyList() {
+            // Given
+            List<MyReviewProjection> myReviewProjections = List.of();
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class, () ->
+                    MyReview.from(myReviewProjections));
+        }
+    }
+
+    @DisplayName("DTO 변환 테스트 (getTopOne, getImages 간접 테스트)")
+    @Nested
+    class ConvertToDTO {
+
+        @DisplayName("성공 - 싱글 이미지")
+        @Test
+        void success_Test_SingleImage() {
+            // Given
+            List<MyReviewProjection> myReviewProjections = List.of(
+                    MyReviewProjection.builder()
+                            .reviewTitle("TestTitle")
+                            .reviewDescription("TestDescription")
+                            .reviewCreatedAt(LocalDateTime.now())
+                            .reviewTaste(Evaluation.GOOD)
+                            .reviewImg("TestImage")
+                            .location("TestLocation")
+                            .build()
+            );
+
+            // When
+            MyReview myReview = MyReview.from(myReviewProjections);
+            MyReviewResponse.DetailDTO actual = myReview.toResponseDTO();
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals("TestTitle", actual.getReviewTitle()),
+                    () -> Assertions.assertEquals(Evaluation.GOOD, actual.getReviewTaste()),
+                    () -> Assertions.assertEquals(1, actual.getReviewImg().size())
+            );
+        }
+
+        @DisplayName("성공 - 여러 이미지")
+        @Test
+        void success_Test_MultipleImage() {
+            // Given
+            List<MyReviewProjection> myReviewProjections = List.of(
+                    MyReviewProjection.builder()
+                            .reviewTitle("TestTitle")
+                            .reviewDescription("TestDescription")
+                            .reviewCreatedAt(LocalDateTime.now())
+                            .reviewTaste(Evaluation.GOOD)
+                            .reviewImg("TestImage1")
+                            .location("TestLocation")
+                            .build(),
+
+                    MyReviewProjection.builder()
+                            .reviewTitle("TestTitle")
+                            .reviewDescription("TestDescription")
+                            .reviewCreatedAt(LocalDateTime.now())
+                            .reviewTaste(Evaluation.GOOD)
+                            .reviewImg("TestImage2")
+                            .location("TestLocation")
+                            .build(),
+
+                    MyReviewProjection.builder()
+                            .reviewTitle("TestTitle")
+                            .reviewDescription("TestDescription")
+                            .reviewCreatedAt(LocalDateTime.now())
+                            .reviewTaste(Evaluation.GOOD)
+                            .reviewImg("TestImage3")
+                            .location("TestLocation")
+                            .build()
+            );
+
+            // When
+            MyReview myReview = MyReview.from(myReviewProjections);
+            MyReviewResponse.DetailDTO actual = myReview.toResponseDTO();
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals("TestTitle", actual.getReviewTitle()),
+                    () -> Assertions.assertEquals(Evaluation.GOOD, actual.getReviewTaste()),
+                    () -> Assertions.assertEquals(3, actual.getReviewImg().size())
+            );
+        }
+    }
+}

--- a/src/test/java/com/livable/server/review/service/MyReviewServiceTest.java
+++ b/src/test/java/com/livable/server/review/service/MyReviewServiceTest.java
@@ -1,0 +1,283 @@
+package com.livable.server.review.service;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.review.dto.MyReviewProjection;
+import com.livable.server.review.dto.MyReviewResponse;
+import com.livable.server.review.repository.MyReviewRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MyReviewServiceTest {
+
+    @Mock
+    private MyReviewRepository myReviewRepository;
+
+    @InjectMocks
+    private MyReviewService myReviewService;
+
+    @Nested
+    @DisplayName("나의 레스토랑 리뷰 서비스 단위 테스트")
+    class MyRestaurantReview {
+
+        @DisplayName("성공 - DTO 변환 테스트 (싱글 이미지)")
+        @Test
+        void success_Test_SingleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String reviewDescription = "맛있오";
+            String imgUrl = "mockImage.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewDescription(reviewDescription).reviewImg(imgUrl).build()
+            );
+
+            Mockito.when(myReviewRepository.findRestaurantReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyRestaurantReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(reviewDescription, actual.getReviewDescription()),
+                    () -> Assertions.assertEquals(1, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl, actual.getReviewImg().get(0))
+            );
+        }
+
+        @DisplayName("성공 - DTO 변환 테스트 (여러 이미지)")
+        @Test
+        void success_Test_MultipleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String imgUrl1 = "mockImage1.jpg";
+            String imgUrl2 = "mockImage2.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewImg(imgUrl1).build(),
+                    MyReviewProjection.builder().reviewImg(imgUrl2).build()
+            );
+
+            Mockito.when(myReviewRepository.findRestaurantReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyRestaurantReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(2, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl1, actual.getReviewImg().get(0)),
+                    () -> Assertions.assertEquals(imgUrl2, actual.getReviewImg().get(1))
+            );
+        }
+
+        @DisplayName("실패 - DTO변환 오류")
+        @Test
+        void failure_Test_FailedConvertToDTO() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+
+            Mockito.when(myReviewRepository.findRestaurantReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(new ArrayList<>());
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class, () ->
+                    myReviewService.getMyRestaurantReview(reviewId, memberId));
+        }
+    }
+
+    @Nested
+    @DisplayName("나의 구내식당 리뷰 서비스 단위 테스트")
+    class MyCafeteriaReview {
+
+        @DisplayName("성공 - DTO 변환 테스트 (싱글 이미지)")
+        @Test
+        void success_Test_SingleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String reviewDescription = "맛있오";
+            String imgUrl = "mockImage.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewDescription(reviewDescription).reviewImg(imgUrl).build()
+            );
+
+            Mockito.when(myReviewRepository.findCafeteriaReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyCafeteriaReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(reviewDescription, actual.getReviewDescription()),
+                    () -> Assertions.assertEquals(1, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl, actual.getReviewImg().get(0))
+            );
+        }
+
+        @DisplayName("성공 - DTO 변환 테스트 (여러 이미지)")
+        @Test
+        void success_Test_MultipleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String imgUrl1 = "mockImage1.jpg";
+            String imgUrl2 = "mockImage2.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewImg(imgUrl1).build(),
+                    MyReviewProjection.builder().reviewImg(imgUrl2).build()
+            );
+
+            Mockito.when(myReviewRepository.findCafeteriaReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyCafeteriaReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(2, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl1, actual.getReviewImg().get(0)),
+                    () -> Assertions.assertEquals(imgUrl2, actual.getReviewImg().get(1))
+            );
+        }
+
+        @DisplayName("실패 - DTO변환 오류")
+        @Test
+        void failure_Test_FailedConvertToDTO() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+
+            Mockito.when(myReviewRepository.findCafeteriaReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(new ArrayList<>());
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class, () ->
+                    myReviewService.getMyCafeteriaReview(reviewId, memberId));
+        }
+    }
+
+    @Nested
+    @DisplayName("나의 도시락 리뷰 서비스 단위 테스트")
+    class MyLunchBoxReview {
+
+        @DisplayName("성공 - DTO 변환 테스트 (싱글 이미지)")
+        @Test
+        void success_Test_SingleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String reviewDescription = "맛있오";
+            String imgUrl = "mockImage.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewDescription(reviewDescription).reviewImg(imgUrl).build()
+            );
+
+            Mockito.when(myReviewRepository.findLunchBoxReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyLunchBoxReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(reviewDescription, actual.getReviewDescription()),
+                    () -> Assertions.assertEquals(1, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl, actual.getReviewImg().get(0))
+            );
+        }
+
+        @DisplayName("성공 - DTO 변환 테스트 (여러 이미지)")
+        @Test
+        void success_Test_MultipleImg() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+            String imgUrl1 = "mockImage1.jpg";
+            String imgUrl2 = "mockImage2.jpg";
+
+            List<MyReviewProjection> mockList = List.of(
+                    MyReviewProjection.builder().reviewImg(imgUrl1).build(),
+                    MyReviewProjection.builder().reviewImg(imgUrl2).build()
+            );
+
+            Mockito.when(myReviewRepository.findLunchBoxReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(mockList);
+
+
+            // When
+            MyReviewResponse.DetailDTO actual = myReviewService.getMyLunchBoxReview(reviewId, memberId);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(2, actual.getReviewImg().size()),
+                    () -> Assertions.assertEquals(imgUrl1, actual.getReviewImg().get(0)),
+                    () -> Assertions.assertEquals(imgUrl2, actual.getReviewImg().get(1))
+            );
+        }
+
+        @DisplayName("실패 - DTO변환 오류")
+        @Test
+        void failure_Test_FailedConvertToDTO() {
+            // Given
+            Long reviewId = 1L;
+            Long memberId = 1L;
+
+            Mockito.when(myReviewRepository.findLunchBoxReviewByReviewId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.anyLong()
+            )).thenReturn(new ArrayList<>());
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class, () ->
+                    myReviewService.getMyLunchBoxReview(reviewId, memberId));
+        }
+    }
+}


### PR DESCRIPTION
review_id를 PathVariable로 제공받아 해당 리뷰의 상세 데이터를 응답한다.
member_id는 JWT에서 추출한다.

- #36 
- 외부식당 리뷰인 경우: 제목(메뉴: selected_dishes)과 위치 정보를 함께 제공한다.
- 구내식당 리뷰인 경우: 메뉴 정보대신 구내식당 문자열을 제공한다. 위치 정보로 빌딩 이름을 제공한다.
- 도시락 리뷰인 경우: 메뉴 정보대신 도시락 문자열을 제공한다.

### 변경정
- 기존에 PathVariable로 받던 reviewType을 각각의GET /api/reviews/{reviewId}/{type}/members
- 기존에 그룹핑과 concat을 사용하여 이미지를 하나의 문자열로 만드는 작업을 비즈니스 로직에서 처리

### 프로세스
- [x] JWT로부터 member_id를 추출한다.
- [x] URI로부터 review_id를 추출한다. (PathVariable)
- [x] Type에 따라 분기한다. (RESTAURANT, CAFETERIA, LUNCHBOX)
- [x] member_id, review_id를 통해 review를 조회한다. (자신이 작성한 리뷰인지 판단하기 위해 member_id도 사용)
- [x] review_id를 사용하여 review테이블과 상세 리뷰 테이블을 조인한다.

### 쿼리

외부식당 리뷰인 경우
```SQL
SELECT 
    review.selected_dishes, 
    restaurant_review.taste, 
    review.description,
    review.created_at,
    restaurant.name,
    review_image.url AS url
FROM review
LEFT JOIN review_image ON review_image.review_id = review.id
INNER JOIN restaurant_review on restaurant_review.id = review.id
INNER JOIN restaurant on restaurant.id = restaurant_review.restaurant_id
WHERE review.id = 475 AND review.member_id = 1;
```

아닌경우
```SQL
SELECT 
    review.selected_dishes as review_title,
    lunch_box_review.taste as review_taste,
    review.description as review_discription,
    review.created_at as review_created_at
FROM review
INNER JOIN lunch_box_review ON lunch_box_review.id = review.id
WHERE review.id = {reviewId} AND member_id = {memberId};
```
```SQL
SELECT 
    review.selected_dishes as review_title,
    cafeteria_review.taste as review_taste,
    review.description as review_discription,
    review.created_at as review_created_at
FROM review
INNER JOIN cafeteria_review ON cafeteria_review.id = review.id
WHERE review.id = {reviewId} AND member_id = {memberId};
```
만약 조회가 안된다면 본인의 리뷰가 아니거나 타입을 잘못 전달한 것

### Issue
- `GROUP CONCAT`은 MySQL에서 사용하는 문법으로 해당 문법을 사용하면 특정 DBMS에 너무 종속적이게 된다. 따라서 `GROUP CONCAT`에서 처리해주던 로직을 애플리케이션 단에서 처리하는 것으로 결정했다.
- 쿼리의 결과를 오브젝트에 매핑한 뒤 쿼리 결과에 대한 권한을 `MyReview`일급 객체에 위임했다. 해당 일급 객체에서 ResponseDTO로의 변환을 수행하는 로직을 가지는 것과, ResponseDTO에서 일급객체를 파라매터로 받는 정적 팩토리 메서드로 가지는 것 어떤 방식이 효율적일까
- 컨트롤러에서 ReviewType을 받아 타입에 따라 각각 다른 서비스 로직을 수행한다. 해당 방법은 확장성이 떨어진다는 단점이 존재한다. 또한 하나의 쿼리결과 매핑 오브젝트에 결과를 담아야 하기 때문에 매핑 오브젝트에 NULL이 존재하게 된다. 따라서 해당 사항 의논 후 엔드포인트를 나누어 처리하는 방향을 고려해보려 한다.

resolved: #36 