### PR TITLE
초대장 수정, 삭제 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/Invitation.java
+++ b/src/main/java/com/livable/server/entity/Invitation.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -41,4 +42,15 @@ public class Invitation extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalTime endTime;
+
+    public void updateDateTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        this.startDate = startDateTime.toLocalDate();
+        this.startTime = startDateTime.toLocalTime();
+        this.endDate = endDateTime.toLocalDate();
+        this.endTime = endDateTime.toLocalTime();
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/livable/server/invitation/controller/InvitationController.java
+++ b/src/main/java/com/livable/server/invitation/controller/InvitationController.java
@@ -59,4 +59,13 @@ public class InvitationController {
         return invitationService.deleteInvitation(invitationId, memberId);
     }
 
+    @PatchMapping("/{invitationId}")
+    public ResponseEntity<?> updateInvitation(
+            @PathVariable Long invitationId, @Valid @RequestBody InvitationRequest.UpdateDTO dto) {
+
+        Long memberId = 1L; // TODO: JWT 토큰에서 추출한 값으로 수정
+
+        return invitationService.updateInvitation(invitationId, dto, memberId);
+    }
+
 }

--- a/src/main/java/com/livable/server/invitation/controller/InvitationController.java
+++ b/src/main/java/com/livable/server/invitation/controller/InvitationController.java
@@ -51,4 +51,12 @@ public class InvitationController {
         return invitationService.getInvitation(invitationId, memberId);
     }
 
+    @DeleteMapping("/{invitationId}")
+    public ResponseEntity<?> deleteInvitation(@PathVariable Long invitationId) {
+
+        Long memberId = 1L; // TODO: JWT 토큰에서 추출한 값으로 수정
+
+        return invitationService.deleteInvitation(invitationId, memberId);
+    }
+
 }

--- a/src/main/java/com/livable/server/invitation/domain/InvitationErrorCode.java
+++ b/src/main/java/com/livable/server/invitation/domain/InvitationErrorCode.java
@@ -12,12 +12,14 @@ public enum InvitationErrorCode implements ErrorCode {
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 회원 정보입니다."),
     INVITATION_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 초대장 정보입니다."),
     INVALID_INTERVIEW_MAXIMUM_NUMBER(HttpStatus.BAD_REQUEST, "면접 초대 가능 인원수는 1명입니다."),
+    INVALID_INVITATION_MAXIMUM_NUMBER(HttpStatus.BAD_REQUEST, "한 초대장에 등록할 수 있는 최대 방문자는 30명입니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "종료 날짜가 시작 날짜보다 과거일 수 없습니다."),
     INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간이 시작 시간보다 과거일 수 없습니다."),
     INVALID_TIME_UNIT(HttpStatus.BAD_REQUEST, "시간의 분 단위는 0분 또는 30분이어야 합니다."),
     INVALID_RESERVATION_COUNT(HttpStatus.BAD_REQUEST, "해당 날짜 또는 시간에 예약된 장소 정보가 없습니다."),
     INVALID_INVITATION_OWNER(HttpStatus.FORBIDDEN, "초대장을 작성한 회원만 접근이 가능합니다."),
-    INVALID_DELETE_DATE(HttpStatus.BAD_REQUEST, "초대장 삭제는 방문일 기준 전날까지만 가능합니다.");
+    INVALID_DELETE_DATE(HttpStatus.BAD_REQUEST, "초대장 삭제는 방문일 기준 전날까지만 가능합니다."),
+    CAN_NOT_CHANGED_COMMON_PLACE_OF_INVITATION(HttpStatus.BAD_REQUEST, "초대장의 예약된 장소는 변경할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/livable/server/invitation/domain/InvitationErrorCode.java
+++ b/src/main/java/com/livable/server/invitation/domain/InvitationErrorCode.java
@@ -10,12 +10,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum InvitationErrorCode implements ErrorCode {
     MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 회원 정보입니다."),
+    INVITATION_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 초대장 정보입니다."),
     INVALID_INTERVIEW_MAXIMUM_NUMBER(HttpStatus.BAD_REQUEST, "면접 초대 가능 인원수는 1명입니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "종료 날짜가 시작 날짜보다 과거일 수 없습니다."),
     INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간이 시작 시간보다 과거일 수 없습니다."),
     INVALID_TIME_UNIT(HttpStatus.BAD_REQUEST, "시간의 분 단위는 0분 또는 30분이어야 합니다."),
     INVALID_RESERVATION_COUNT(HttpStatus.BAD_REQUEST, "해당 날짜 또는 시간에 예약된 장소 정보가 없습니다."),
-    INVALID_INVITATION_OWNER(HttpStatus.FORBIDDEN, "초대장을 작성한 회원만 접근이 가능합니다.");
+    INVALID_INVITATION_OWNER(HttpStatus.FORBIDDEN, "초대장을 작성한 회원만 접근이 가능합니다."),
+    INVALID_DELETE_DATE(HttpStatus.BAD_REQUEST, "초대장 삭제는 방문일 기준 전날까지만 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/livable/server/invitation/dto/InvitationRequest.java
+++ b/src/main/java/com/livable/server/invitation/dto/InvitationRequest.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
 import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -91,6 +92,7 @@ public class InvitationRequest {
         @FutureOrPresent(message = REQUIRED_FUTURE_DATE)
         private LocalDateTime endDate;
 
+        @Valid
         @NotNull(message = NOT_NULL)
         private List<VisitorForUpdateDTO> visitors;
     }
@@ -98,7 +100,10 @@ public class InvitationRequest {
     @Getter
     @Builder
     public static class VisitorForUpdateDTO {
+        @NotNull(message = NOT_NULL)
         private String name;
+
+        @NotNull(message = NOT_NULL)
         private String contact;
 
         public Visitor toEntity(Invitation invitation) {

--- a/src/main/java/com/livable/server/invitation/dto/InvitationRequest.java
+++ b/src/main/java/com/livable/server/invitation/dto/InvitationRequest.java
@@ -77,4 +77,38 @@ public class InvitationRequest {
         }
     }
 
+    @Getter
+    @Builder
+    public static class UpdateDTO {
+        private Long commonPlaceId;
+        private String description;
+
+        @NotNull(message = NOT_NULL)
+        @FutureOrPresent(message = REQUIRED_FUTURE_DATE)
+        private LocalDateTime startDate;
+
+        @NotNull(message = NOT_NULL)
+        @FutureOrPresent(message = REQUIRED_FUTURE_DATE)
+        private LocalDateTime endDate;
+
+        @NotNull(message = NOT_NULL)
+        private List<VisitorForUpdateDTO> visitors;
+    }
+
+    @Getter
+    @Builder
+    public static class VisitorForUpdateDTO {
+        private String name;
+        private String contact;
+
+        public Visitor toEntity(Invitation invitation) {
+            return Visitor.builder()
+                    .invitation(invitation)
+                    .name(name)
+                    .contact(contact)
+                    .firstVisitedTime(null)
+                    .build();
+        }
+    }
+
 }

--- a/src/main/java/com/livable/server/invitation/repository/InvitationQueryRepository.java
+++ b/src/main/java/com/livable/server/invitation/repository/InvitationQueryRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface InvitationQueryRepository {
     List<InvitationResponse.ListDTO> findInvitationsByMemberId(Long memberId);
     InvitationResponse.DetailDTO findInvitationAndVisitorsByInvitationId(Long invitationId);
+    Long getCommonPlaceIdByInvitationId(Long invitationId);
 }

--- a/src/main/java/com/livable/server/invitation/repository/InvitationQueryRepositoryImpl.java
+++ b/src/main/java/com/livable/server/invitation/repository/InvitationQueryRepositoryImpl.java
@@ -91,4 +91,17 @@ public class InvitationQueryRepositoryImpl implements InvitationQueryRepository 
 
         return invitationDetail;
     }
+
+    @Override
+    public Long getCommonPlaceIdByInvitationId(Long invitationId) {
+        return queryFactory
+                .select(reservation.commonPlace.id)
+                .from(invitation)
+                .leftJoin(invitationReservationMap)
+                .on(invitationReservationMap.invitation.id.eq(invitation.id))
+                .leftJoin(reservation)
+                .on(reservation.id.eq(invitationReservationMap.reservation.id))
+                .where(invitation.id.eq(invitationId))
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/livable/server/invitation/repository/InvitationReservationMapRepository.java
+++ b/src/main/java/com/livable/server/invitation/repository/InvitationReservationMapRepository.java
@@ -2,6 +2,12 @@ package com.livable.server.invitation.repository;
 
 import com.livable.server.entity.InvitationReservationMap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InvitationReservationMapRepository extends JpaRepository<InvitationReservationMap, Long> {
+
+    @Modifying
+    @Query("delete from InvitationReservationMap irm where irm.invitation.id = :invitationId")
+    void deleteAllByInvitationId(Long invitationId);
 }

--- a/src/main/java/com/livable/server/invitation/service/InvitationService.java
+++ b/src/main/java/com/livable/server/invitation/service/InvitationService.java
@@ -338,18 +338,19 @@ public class InvitationService {
     }
 
     private boolean checkAddedVisitorsCount(Invitation invitation, InvitationRequest.UpdateDTO dto) {
-        if (invitation.getPurpose().equals(InvitationPurpose.INTERVIEW.getValue())) {
+        long addedCount = dto.getVisitors().size();
+
+        if (addedCount != 0L && invitation.getPurpose().equals(InvitationPurpose.INTERVIEW.getValue())) {
             throw new GlobalRuntimeException(InvitationErrorCode.INVALID_INTERVIEW_MAXIMUM_NUMBER);
         }
 
         long alreadyCount = visitorRepository.countByInvitation(invitation);
-        long addedCount = dto.getVisitors().size();
 
         if (alreadyCount + addedCount > INVITATION_MAXIMUM_COUNT) {
             throw new GlobalRuntimeException(InvitationErrorCode.INVALID_INVITATION_MAXIMUM_NUMBER);
         }
 
-        return dto.getVisitors().size() != 0;
+        return addedCount != 0;
     }
 
     private boolean isModifiedInvitationDateTime(Invitation invitation, InvitationRequest.UpdateDTO dto) {

--- a/src/main/java/com/livable/server/invitation/service/InvitationService.java
+++ b/src/main/java/com/livable/server/invitation/service/InvitationService.java
@@ -108,7 +108,7 @@ public class InvitationService {
     }
 
     private Long getCompanyIdByMemberId(Long memberId) {
-        Member member = findMemberById(memberId);
+        Member member = checkExistMemberById(memberId);
 
         return member.getCompany().getId();
     }
@@ -117,7 +117,7 @@ public class InvitationService {
     public ResponseEntity<?> createInvitation(InvitationRequest.CreateDTO dto, Long memberId) {
         checkInterviewVisitorCount(dto);
 
-        Member member = findMemberById(memberId);
+        Member member = checkExistMemberById(memberId);
         Invitation invitation = createInvitation(dto, member);
         createVisitors(dto.getVisitors(), invitation);
         reserveCommonPlaces(dto, invitation);
@@ -133,7 +133,7 @@ public class InvitationService {
         }
     }
 
-    private Member findMemberById(Long memberId) {
+    private Member checkExistMemberById(Long memberId) {
         Optional<Member> memberOptional = memberRepository.findById(memberId);
 
         return memberOptional.orElseThrow(() -> new GlobalRuntimeException(InvitationErrorCode.MEMBER_NOT_EXIST));
@@ -223,16 +223,16 @@ public class InvitationService {
 
     @Transactional(readOnly = true)
     public ResponseEntity<Success<List<InvitationResponse.ListDTO>>> getInvitations(Long memberId) {
-        Member member = findMemberById(memberId);
-        List<InvitationResponse.ListDTO> invitationDTOs = invitationRepository.findInvitationsByMemberId(member.getId());
+        checkExistMemberById(memberId);
+        List<InvitationResponse.ListDTO> invitationDTOs = invitationRepository.findInvitationsByMemberId(memberId);
 
         return ApiResponse.success(invitationDTOs, HttpStatus.OK);
     }
 
     @Transactional(readOnly = true)
     public ResponseEntity<Success<InvitationResponse.DetailDTO>> getInvitation(Long invitationId, Long memberId) {
-        Member member = findMemberById(memberId);
-        checkInvitationOwner(invitationId, member.getId());
+        checkExistMemberById(memberId);
+        checkInvitationOwner(invitationId, memberId);
 
         InvitationResponse.DetailDTO invitationDTO
                 = invitationRepository.findInvitationAndVisitorsByInvitationId(invitationId);

--- a/src/main/java/com/livable/server/visitation/repository/ParkingLogRepository.java
+++ b/src/main/java/com/livable/server/visitation/repository/ParkingLogRepository.java
@@ -2,9 +2,11 @@ package com.livable.server.visitation.repository;
 
 import com.livable.server.entity.ParkingLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParkingLogRepository extends JpaRepository<ParkingLog, Long> {
@@ -12,4 +14,8 @@ public interface ParkingLogRepository extends JpaRepository<ParkingLog, Long> {
     @Query("select p from ParkingLog p" +
             " where p.visitor.id = :visitorId")
     Optional<ParkingLog> findParkingLogByVisitorId(@Param("visitorId") final Long visitorId);
+
+    @Modifying
+    @Query("delete from ParkingLog p where p.visitor.id in :visitorIds")
+    void deleteByVisitorIdsIn(@Param("visitorIds") List<Long> visitorIds);
 }

--- a/src/main/java/com/livable/server/visitation/repository/VisitorRepository.java
+++ b/src/main/java/com/livable/server/visitation/repository/VisitorRepository.java
@@ -15,4 +15,6 @@ public interface VisitorRepository extends JpaRepository<Visitor, Long>, Visitor
     @Modifying
     @Query("delete from Visitor v where v.id in :ids")
     void deleteByIdsIn(@Param("ids") List<Long> ids);
+
+    long countByInvitation(Invitation invitation);
 }

--- a/src/main/java/com/livable/server/visitation/repository/VisitorRepository.java
+++ b/src/main/java/com/livable/server/visitation/repository/VisitorRepository.java
@@ -1,7 +1,18 @@
 package com.livable.server.visitation.repository;
 
+import com.livable.server.entity.Invitation;
 import com.livable.server.entity.Visitor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface VisitorRepository extends JpaRepository<Visitor, Long>, VisitorCustomRepository {
+    List<Visitor> findVisitorsByInvitation(Invitation invitation);
+
+    @Modifying
+    @Query("delete from Visitor v where v.id in :ids")
+    void deleteByIdsIn(@Param("ids") List<Long> ids);
 }

--- a/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
+++ b/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
@@ -14,6 +14,7 @@ import com.livable.server.invitation.repository.OfficeRepository;
 import com.livable.server.invitation.service.data.InvitationBasicData;
 import com.livable.server.member.repository.MemberRepository;
 import com.livable.server.reservation.repository.ReservationRepository;
+import com.livable.server.visitation.repository.ParkingLogRepository;
 import com.livable.server.visitation.repository.VisitorRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,9 @@ class InvitationServiceTest {
 
     @Mock
     private InvitationReservationMapRepository invitationReservationMapRepository;
+
+    @Mock
+    private ParkingLogRepository parkingLogRepository;
 
     @InjectMocks
     private InvitationService invitationService;
@@ -421,6 +425,73 @@ class InvitationServiceTest {
         // When
         ResponseEntity<Success<InvitationResponse.DetailDTO>> result
                 = invitationService.getInvitation(invitationId, memberId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @DisplayName("[실패] 초대장 삭제 - 존재하지 않는 초대장인 경우")
+    @Test
+    void deleteInvitationFail_01() {
+        // Given
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.deleteInvitation(invitationId, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.INVITATION_NOT_EXIST);
+    }
+
+    @DisplayName("[실패] 초대장 삭제 - 삭제 요청 날짜가 방문 날짜 이후인 경우")
+    @Test
+    void deleteInvitationFail_02() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .startDate(requestDate.minusDays(1L))
+                        .build()
+                ));
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.deleteInvitation(invitationId, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.INVALID_DELETE_DATE);
+    }
+
+    @DisplayName("[성공] 초대장 삭제")
+    @Test
+    void deleteInvitationFail_03() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .startDate(requestDate.plusDays(1L))
+                        .build()
+                ));
+        given(visitorRepository.findVisitorsByInvitation(any(Invitation.class)))
+                .willReturn(List.of(Visitor.builder().build()));
+
+        // When
+        ResponseEntity<?> result = invitationService.deleteInvitation(invitationId, memberId);
 
         // Then
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
+++ b/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
@@ -497,6 +497,319 @@ class InvitationServiceTest {
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
+    @DisplayName("[실패] 초대장 수정 - 초대장 방문 날짜가 요청 날짜보다 과거인 경우")
+    @Test
+    void updateInvitationFail_01() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateBeforeRequestDate = requestDate.minusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder().build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .startDate(dateBeforeRequestDate)
+                        .build()
+                ));
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.updateInvitation(invitationId, dto, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.INVALID_DELETE_DATE);
+    }
+
+    @DisplayName("[실패] 초대장 수정 - 기존에 예약된 장소가 변경된 경우")
+    @Test
+    void updateInvitationFail_02() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .startDate(dateAfterRequestDate)
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong()))
+                .willReturn(dto.getCommonPlaceId() + 1L);
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.updateInvitation(invitationId, dto, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.CAN_NOT_CHANGED_COMMON_PLACE_OF_INVITATION);
+    }
+
+    @DisplayName("[실패] 초대장 수정 - 목적인 면접인데 추가 방문자가 있는 경우")
+    @Test
+    void updateInvitationFail_03() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(List.of(InvitationRequest.VisitorForUpdateDTO.builder().build()))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("면접")
+                        .startDate(dateAfterRequestDate)
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.updateInvitation(invitationId, dto, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.INVALID_INTERVIEW_MAXIMUM_NUMBER);
+    }
+
+    @DisplayName("[실패] 초대장 수정 - 최대 방문자 수를 넘어간 경우")
+    @Test
+    void updateInvitationFail_04() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(List.of(InvitationRequest.VisitorForUpdateDTO.builder().build()))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("회의")
+                        .startDate(dateAfterRequestDate)
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+        given(visitorRepository.countByInvitation(any(Invitation.class))).willReturn(30L);
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationService.updateInvitation(invitationId, dto, memberId));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(InvitationErrorCode.INVALID_INVITATION_MAXIMUM_NUMBER);
+    }
+
+    @DisplayName("[성공] 초대장 수정 - 시간 변경 X, 인원 추가 X")
+    @Test
+    void updateInvitationSuccess_01() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(List.of())
+                .startDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(10, 0, 0)))
+                .endDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(10, 30, 0)))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("회의")
+                        .startDate(dateAfterRequestDate)
+                        .endDate(dateAfterRequestDate)
+                        .startTime(LocalTime.of(10, 0, 0))
+                        .endTime(LocalTime.of(10, 30, 0))
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+        given(visitorRepository.countByInvitation(any(Invitation.class))).willReturn(29L);
+
+        // When
+        ResponseEntity<?> result = invitationService.updateInvitation(invitationId, dto, memberId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @DisplayName("[성공] 초대장 수정 - 시간 변경 X, 인원 추가 O")
+    @Test
+    void updateInvitationSuccess_02() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(
+                        List.of(
+                                InvitationRequest.VisitorForUpdateDTO.builder().build(),
+                                InvitationRequest.VisitorForUpdateDTO.builder().build(),
+                                InvitationRequest.VisitorForUpdateDTO.builder().build()
+                        )
+                )
+                .startDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(10, 0, 0)))
+                .endDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(10, 30, 0)))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong()))
+                .willReturn(Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("회의")
+                        .startDate(dateAfterRequestDate)
+                        .endDate(dateAfterRequestDate)
+                        .startTime(LocalTime.of(10, 0, 0))
+                        .endTime(LocalTime.of(10, 30, 0))
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+        given(visitorRepository.countByInvitation(any(Invitation.class))).willReturn(1L);
+        given(visitorRepository.saveAll(any())).willReturn(List.of(Visitor.builder().build()));
+
+        // When
+        ResponseEntity<?> result = invitationService.updateInvitation(invitationId, dto, memberId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @DisplayName("[성공] 초대장 수정 - 시간 변경 O, 인원 추가 X")
+    @Test
+    void updateInvitationSuccess_03() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(List.of())
+                .startDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(11, 0, 0)))
+                .endDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(11, 30, 0)))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong())).willReturn(
+                Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("회의")
+                        .startDate(dateAfterRequestDate)
+                        .endDate(dateAfterRequestDate)
+                        .startTime(LocalTime.of(10, 0, 0))
+                        .endTime(LocalTime.of(10, 30, 0))
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+        given(visitorRepository.countByInvitation(any(Invitation.class))).willReturn(3L);
+        given(visitorRepository.findVisitorsByInvitation(any(Invitation.class))).willReturn(
+                List.of(
+                        Visitor.builder().build(),
+                        Visitor.builder().build(),
+                        Visitor.builder().build()
+                ));
+        given(reservationRepository.findReservationsByCommonPlaceIdAndStartDateAndEndDate(
+                anyLong(),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class)
+        )).willReturn(List.of(Reservation.builder().build()));
+
+        // When
+        ResponseEntity<?> result = invitationService.updateInvitation(invitationId, dto, memberId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @DisplayName("[성공] 초대장 수정 - 시간 변경 O, 인원 추가 O")
+    @Test
+    void updateInvitationSuccess_04() {
+        // Given
+        LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
+        Long invitationId = 1L;
+        Long memberId = 1L;
+        Long commonPlaceId = 1L;
+        InvitationRequest.UpdateDTO dto = InvitationRequest.UpdateDTO.builder()
+                .commonPlaceId(commonPlaceId)
+                .visitors(
+                        List.of(
+                                InvitationRequest.VisitorForUpdateDTO.builder().build(),
+                                InvitationRequest.VisitorForUpdateDTO.builder().build(),
+                                InvitationRequest.VisitorForUpdateDTO.builder().build()
+                        )
+                )
+                .startDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(11, 0, 0)))
+                .endDate(LocalDateTime.of(dateAfterRequestDate, LocalTime.of(11, 30, 0)))
+                .build();
+
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
+        given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
+        given(invitationRepository.findById(anyLong())).willReturn(
+                Optional.of(Invitation.builder()
+                        .id(invitationId)
+                        .purpose("회의")
+                        .startDate(dateAfterRequestDate)
+                        .endDate(dateAfterRequestDate)
+                        .startTime(LocalTime.of(10, 0, 0))
+                        .endTime(LocalTime.of(10, 30, 0))
+                        .build()
+                ));
+        given(invitationRepository.getCommonPlaceIdByInvitationId(anyLong())).willReturn(dto.getCommonPlaceId());
+        given(visitorRepository.countByInvitation(any(Invitation.class))).willReturn(3L);
+        given(visitorRepository.findVisitorsByInvitation(any(Invitation.class))).willReturn(
+                List.of(
+                        Visitor.builder().build(),
+                        Visitor.builder().build(),
+                        Visitor.builder().build()
+                ));
+        given(reservationRepository.findReservationsByCommonPlaceIdAndStartDateAndEndDate(
+                anyLong(),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class)
+        )).willReturn(List.of(Reservation.builder().build()));
+
+        // When
+        ResponseEntity<?> result = invitationService.updateInvitation(invitationId, dto, memberId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
     private List<InvitationResponse.ReservationDTO> createReservations() {
         return new ArrayList<>(List.of(
                 new InvitationResponse.ReservationDTO(

--- a/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
+++ b/src/test/java/com/livable/server/invitation/service/InvitationServiceTest.java
@@ -400,6 +400,7 @@ class InvitationServiceTest {
         // Given
         Long invitationId = 1L;
         Long memberId = 1L;
+
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
         given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(0L);
 
@@ -417,6 +418,7 @@ class InvitationServiceTest {
         // Given
         Long invitationId = 1L;
         Long memberId = 1L;
+
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
         given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
         given(invitationRepository.findInvitationAndVisitorsByInvitationId(anyLong()))
@@ -436,6 +438,7 @@ class InvitationServiceTest {
         // Given
         Long invitationId = 1L;
         Long memberId = 1L;
+
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
         given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
         given(invitationRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -453,14 +456,16 @@ class InvitationServiceTest {
     void deleteInvitationFail_02() {
         // Given
         LocalDate requestDate = LocalDate.now();
+        LocalDate dateBeforeRequestDate = requestDate.minusDays(1L);
         Long invitationId = 1L;
         Long memberId = 1L;
+
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
         given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
         given(invitationRepository.findById(anyLong()))
                 .willReturn(Optional.of(Invitation.builder()
                         .id(invitationId)
-                        .startDate(requestDate.minusDays(1L))
+                        .startDate(dateBeforeRequestDate)
                         .build()
                 ));
 
@@ -477,14 +482,16 @@ class InvitationServiceTest {
     void deleteInvitationFail_03() {
         // Given
         LocalDate requestDate = LocalDate.now();
+        LocalDate dateAfterRequestDate = requestDate.plusDays(1L);
         Long invitationId = 1L;
         Long memberId = 1L;
+
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(Member.builder().id(memberId).build()));
         given(invitationRepository.countByIdAndMemberId(anyLong(), anyLong())).willReturn(1L);
         given(invitationRepository.findById(anyLong()))
                 .willReturn(Optional.of(Invitation.builder()
                         .id(invitationId)
-                        .startDate(requestDate.plusDays(1L))
+                        .startDate(dateAfterRequestDate)
                         .build()
                 ));
         given(visitorRepository.findVisitorsByInvitation(any(Invitation.class)))


### PR DESCRIPTION
- #57 

<br>

### TODO
- [x] 초대장 삭제 기능 구현
- [x] 초대장 삭제 Service 테스트 구현
- [x] 초대장 삭제 POSTMAN 테스트
- [x] 초대장 수정 기능 구현
- [x] 초대장 수정 POSTMAN 테스트
- [x] 초대장 수정 Service 테스트 구현
- [x] 초대장 수정 Controller 테스트 구현 (유효성 검사 확인)

<br>

### 삭제 프로세스
(1) `DELETE` /api/invitation/{invitationId}
(2) 요청 받은 `invitationId`로 초대장을 조회
(3) 초대장이 존재하는지 확인, 요청한 `Member`가 작성한 초대장이 맞는지 확인
(4) 초대장 방문 날짜가 지났는지 확인
  - 이미 지난 날짜의 초대장은 삭제되지 않도록 해야 한다.
  - 주차 등록이나 여러 데이터가 묶여 있기 때문에
  - 애초에 클라이언트는 지난 초대장에 대해서 리스트를 넘겨 받지 않는다.
  
(5) 초대장에 등록된 장소가 예약한 장소(`commonPlace`)라면 해당 초대장에 연결 되어 있는 모든 예약 정보 삭제
(6) 초대장에 등록 되었던 방문자 데이터 + 주차 등록 데이터 모두 삭제

<br>

### 삭제 벌크 연산
```java
@Modifying
@Query("delete from InvitationReservationMap irm where irm.invitation.id = :invitationId")
void deleteAllByInvitationId(Long invitationId);
```
- 내가 작성하는 코드에서는 1차 캐싱에 대한 이슈가 없어서 벌크연산을 사용했다.
- 근데 만약 해당 메서드를 다른 작업자가 재사용한다면 잠재적인 문제를 일으킬 수 있지 않을까?
- 주석으로 표시를 해둬야하지? 어떻게 표시해야할지 고민을 조금 더 해봐야겠다.

<br><hr>

### 수정 프로세스
(1) `PATCH` /api/invitation/{invitationId}
(2) Request 받은 데이터들로 변경 감지를 통한 데이터 수정을 진행
(3) 수정할 수 없는 값 들에 대한 유효성 검사를 진행

<br>

### 수정 기능 고려 사항
(1) 초대목적 (`purpose`)는 수정이 불가하다.
(2) 초대목록 (`visitors`)는 추가만 가능하다. (삭제는 불가능)
  - 추가된 인원에게만 알림톡을 보낸다.
  - 만약 초대장의 시간이 변경된 경우에는 모두에게 알림톡을 다시 보낸다.
  
(3) 예약된 장소를 사용하지 않은 초대장의 초대일시 (`date`, `time`)는 변경이 가능하다.
  - commonPlaceId가 `null`이면 초대일시 변경은 가능하다.
  
(4) 예약된 장소를 사용하고, 목적이 면접이라면 초대일시 변경이 가능하다.
  - commonPlaceId가 null이 아니라면 목적이 면접 때만 변경이 가능하다.
  
(5) 팁 작성(description)은 수정이 가능하다.

<br>

### 수정 기능 중
```java
  if (isModifiedInvitationDateTime(invitation, dto)) {
      shouldSendToAlreadyVisitor = true;
      if (isReservedCommonPlace(dto.getCommonPlaceId())) {
  
          invitationReservationMapRepository.deleteAllByInvitationId(invitation.getId());
          reserveNewCommonPlaces(dto, invitation);
      }
  }
```
- `deleteAllByInvitationId` 벌크 삭제 쿼리를 사용 후
- `reserveNewCommonPlaces` 새로운 예약 내역을 만듬
- 기존 시간과 겹치는 시간을 예약하는 경우도 생각해서 완전히 연관된 예약은 지우고, 새롭게 다시 예약하는게 안전하다고 판단

<br>

### Issue
- DTO안에 있는 다른 DTO의 리스트 Validation 검증?
  ```java
  @Getter
  @Builder
  public static class UpdateDTO {
      private Long commonPlaceId;
      private String description;
  
      @NotNull(message = NOT_NULL)
      @FutureOrPresent(message = REQUIRED_FUTURE_DATE)
      private LocalDateTime startDate;
  
      @NotNull(message = NOT_NULL)
      @FutureOrPresent(message = REQUIRED_FUTURE_DATE)
      private LocalDateTime endDate;
  
      @Valid
      @NotNull(message = NOT_NULL)
      private List<VisitorForUpdateDTO> visitors;
  }
  
  @Getter
  @Builder
  public static class VisitorForUpdateDTO {
      @NotNull(message = NOT_NULL)
      private String name;
  
      @NotNull(message = NOT_NULL)
      private String contact;
  
      public Visitor toEntity(Invitation invitation) {
          return Visitor.builder()
                  .invitation(invitation)
                  .name(name)
                  .contact(contact)
                  .firstVisitedTime(null)
                  .build();
      }
  }
  ```
  - private List<VisitorForUpdateDTO> visitors의 요소 하나하나 Validation 검사를 하기 위해서는 여기에도 @Valid를 붙여줘야 한다.