### PR TITLE
오점완 리뷰 상세 페이지 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
@@ -42,4 +42,12 @@ public class RestaurantReviewController {
 
         return ApiResponse.success(allListForMenu, HttpStatus.OK);
     }
+
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse.Success<RestaurantReviewResponse.DetailDTO>> detail(@PathVariable Long reviewId) {
+
+        RestaurantReviewResponse.DetailDTO detail = restaurantReviewService.getDetail(reviewId);
+
+        return ApiResponse.success(detail, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/livable/server/review/dto/Projection.java
+++ b/src/main/java/com/livable/server/review/dto/Projection.java
@@ -1,0 +1,30 @@
+package com.livable.server.review.dto;
+
+import com.livable.server.entity.Evaluation;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Projection {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    static public class RestaurantReview {
+
+        private String memberName;
+
+        private Long restaurantId;
+        private String restaurantName;
+
+        private LocalDateTime reviewCreatedAt;
+        private String reviewDescription;
+        private Evaluation reviewTaste;
+        private Evaluation reviewAmount;
+        private Evaluation reviewService;
+        private Evaluation reviewSpeed;
+
+        private String reviewImg;
+    }
+}

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
@@ -4,6 +4,7 @@ import com.livable.server.entity.Evaluation;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RestaurantReviewResponse {
@@ -50,5 +51,39 @@ public class RestaurantReviewResponse {
 
         private Long memberId;
         private String memberName;
+    }
+
+    @Getter
+    @Builder
+    public static class DetailDTO {
+
+        private String memberName;
+
+        private Long restaurantId;
+        private String restaurantName;
+
+        private LocalDateTime reviewCreatedAt;
+        private String reviewDescription;
+        private Evaluation reviewTaste;
+        private Evaluation reviewAmount;
+        private Evaluation reviewService;
+        private Evaluation reviewSpeed;
+
+        private List<String> reviewImages;
+
+        public static DetailDTO from(Projection.RestaurantReview restaurantReview, List<String> reviewImages) {
+            return DetailDTO.builder()
+                    .memberName(restaurantReview.getMemberName())
+                    .restaurantId(restaurantReview.getRestaurantId())
+                    .restaurantName(restaurantReview.getRestaurantName())
+                    .reviewCreatedAt(restaurantReview.getReviewCreatedAt())
+                    .reviewDescription(restaurantReview.getReviewDescription())
+                    .reviewTaste(restaurantReview.getReviewTaste())
+                    .reviewAmount(restaurantReview.getReviewAmount())
+                    .reviewService(restaurantReview.getReviewService())
+                    .reviewSpeed(restaurantReview.getReviewSpeed())
+                    .reviewImages(reviewImages)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepository.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepository.java
@@ -1,12 +1,17 @@
 package com.livable.server.review.repository;
 
+import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface RestaurantReviewCustomRepository {
 
     Page<RestaurantReviewResponse.ListDTO> findRestaurantReviewByBuildingId(Long buildingId, Pageable pageable);
 
     Page<RestaurantReviewResponse.ListForMenuDTO> findRestaurantReviewByMenuId(Long menuId, Pageable pageable);
+
+    List<Projection.RestaurantReview> findRestaurantReviewById(Long reviewId);
 }

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewCustomRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.livable.server.review.repository;
 
 import com.livable.server.entity.*;
+import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
-import com.querydsl.core.QueryFactory;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -18,6 +18,7 @@ import static com.livable.server.entity.QMember.member;
 import static com.livable.server.entity.QRestaurant.restaurant;
 import static com.livable.server.entity.QRestaurantReview.restaurantReview;
 import static com.livable.server.entity.QReview.review;
+import static com.livable.server.entity.QReviewImage.reviewImage;
 import static com.livable.server.entity.QReviewMenuMap.reviewMenuMap;
 
 @RequiredArgsConstructor
@@ -107,5 +108,29 @@ public class RestaurantReviewCustomRepositoryImpl implements RestaurantReviewCus
         long total = query.fetchCount();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<Projection.RestaurantReview> findRestaurantReviewById(Long reviewId) {
+        return queryFactory
+                .select(Projections.constructor(Projection.RestaurantReview.class,
+                        member.name,
+                        restaurant.id,
+                        restaurant.name,
+                        review.createdAt,
+                        review.description,
+                        restaurantReview.taste,
+                        restaurantReview.amount,
+                        restaurantReview.service,
+                        restaurantReview.speed,
+                        reviewImage.url
+                ))
+                .from(review)
+                .innerJoin(restaurantReview).on(restaurantReview.id.eq(review.id))
+                .innerJoin(member).on(member.id.eq(review.member.id))
+                .innerJoin(restaurant).on(restaurant.id.eq(restaurantReview.restaurant.id))
+                .leftJoin(reviewImage).on(reviewImage.review.id.eq(review.id))
+                .where(review.id.eq(reviewId))
+                .fetch();
     }
 }

--- a/src/main/java/com/livable/server/review/service/MyReviewService.java
+++ b/src/main/java/com/livable/server/review/service/MyReviewService.java
@@ -6,6 +6,7 @@ import com.livable.server.review.dto.MyReviewResponse;
 import com.livable.server.review.repository.MyReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,6 +16,7 @@ public class MyReviewService {
 
     private final MyReviewRepository myReviewRepository;
 
+    @Transactional(readOnly = true)
     public MyReviewResponse.DetailDTO getMyRestaurantReview(Long reviewId, Long memberId) {
 
         List<MyReviewProjection> myReviewProjections
@@ -23,6 +25,7 @@ public class MyReviewService {
         return this.convertToDTO(myReviewProjections);
     }
 
+    @Transactional(readOnly = true)
     public MyReviewResponse.DetailDTO getMyCafeteriaReview(Long reviewId, Long memberId) {
 
         List<MyReviewProjection> myReviewProjections
@@ -31,6 +34,7 @@ public class MyReviewService {
         return this.convertToDTO(myReviewProjections);
     }
 
+    @Transactional(readOnly = true)
     public MyReviewResponse.DetailDTO getMyLunchBoxReview(Long reviewId, Long memberId) {
 
         List<MyReviewProjection> myReviewProjections

--- a/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
+++ b/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
@@ -1,5 +1,9 @@
 package com.livable.server.review.service;
 
+import com.livable.server.core.exception.ErrorCode;
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.review.domain.MyReviewErrorCode;
+import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
 import com.livable.server.review.repository.RestaurantReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +11,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -22,5 +29,23 @@ public class RestaurantReviewService {
     @Transactional(readOnly = true)
     public Page<RestaurantReviewResponse.ListForMenuDTO> getAllListForMenu(Long menuId, Pageable pageable) {
         return restaurantReviewRepository.findRestaurantReviewByMenuId(menuId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public RestaurantReviewResponse.DetailDTO getDetail(Long reviewId) {
+
+        List<Projection.RestaurantReview> restaurantReviews
+                = restaurantReviewRepository.findRestaurantReviewById(reviewId);
+
+        if (restaurantReviews.isEmpty()) {
+            throw new GlobalRuntimeException(MyReviewErrorCode.REVIEW_NOT_EXIST);
+        }
+
+        Projection.RestaurantReview restaurantReview = restaurantReviews.get(0);
+        List<String> reviewImages = restaurantReviews.stream()
+                .map(Projection.RestaurantReview::getReviewImg)
+                .collect(Collectors.toList());
+
+        return RestaurantReviewResponse.DetailDTO.from(restaurantReview, reviewImages);
     }
 }

--- a/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.livable.server.review.controller;
 
+import com.livable.server.review.dto.MyReviewResponse;
 import com.livable.server.review.dto.RestaurantReviewResponse;
 import com.livable.server.review.service.RestaurantReviewService;
 import org.junit.jupiter.api.DisplayName;
@@ -107,6 +108,31 @@ class RestaurantReviewControllerTest {
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").isArray())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.length()").value(10));
+        }
+    }
+
+    @Nested
+    @DisplayName("레스토랑 리뷰 상세 정보 컨트롤러 단위 테스트")
+    class Detail {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            String uri = "/api/reviews/1";
+
+            RestaurantReviewResponse.DetailDTO detailDTO
+                    = RestaurantReviewResponse.DetailDTO.builder().build();
+
+            Mockito.when(restaurantReviewService.getDetail(ArgumentMatchers.anyLong()))
+                    .thenReturn(detailDTO);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists());
         }
     }
 }


### PR DESCRIPTION
리뷰를 클릭했을 때 진입하는 리뷰 상세보기 페이지에 필요한 데이터를 응답한다.
- `GET` /api/reviews/{reviewId}
- #62 

### 프로세스
- [x] PathVariable로 전달된 reviewId를 추출한다.
- [x] reviewId를 통해 Review를 조회한다. (CreatedAt)
- [x] Review를 통해 Member를 조회한다. (memberName, profileImages)
- [x] Review를 통해 RestaurantReview를 조회한다. (taste, amount, service, speed)
- [x] Review를 통해 ReviewImageMap을 조회한다. (reviewImages)
- [x] RestaurantReview를 통해 Restaurant를 조회한다. (restaurantName)

### 쿼리
``` SQL
SELECT 
    member.name,
    restaurant.id,
    restaurant.name,
    review.created_at,
    review.description,
    restaurant_review.taste,
    restaurant_review.amount,
    restaurant_review.service,
    restaurant_review.speed,
    review_image.url
FROM review
INNER JOIN restaurant_review ON restaurant_review.id = review.id
INNER JOIN member ON member.id = review.member_id
INNER JOIN restaurant ON restaurant.id = restaurant_review.restaurant_id
LEFT JOIN review_image ON review_image.review_id = review.id
WHERE review.id = {reviewId};
```

### Issue
``` java
if (restaurantReviews.isEmpty()) {
    throw new GlobalRuntimeException(MyReviewErrorCode.REVIEW_NOT_EXIST);
}

Projection.RestaurantReview restaurantReview = restaurantReviews.get(0);
List<String> reviewImages = restaurantReviews.stream()
        .map(Projection.RestaurantReview::getReviewImg)
        .collect(Collectors.toList());

return RestaurantReviewResponse.DetailDTO.from(restaurantReview, reviewImages);
```
위와 같이 쿼리 결과가 정상적인지 체크하고
쿼리 결과의 특정 데이터를 추출하여 응답에 알맞게 변환작업을 거친 뒤
응답 객체로 파싱하는 작업을 서비스 메서드에서 하는 것이 옳을지

MyReview 클래스 같이 일급 객체로 만들어서 관리함과 동시에 로직을 수행하는 것이 좋을지 고민

resolved: #62 