### PR TITLE
홈 화면에 필요한 정보 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/home/controller/HomeController.java
+++ b/src/main/java/com/livable/server/home/controller/HomeController.java
@@ -1,0 +1,29 @@
+package com.livable.server.home.controller;
+
+import com.livable.server.core.response.ApiResponse;
+import com.livable.server.home.dto.HomeResponse.BuildingInfoDto;
+import com.livable.server.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+@RestController
+public class HomeController {
+
+	private final MemberService memberService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse.Success<BuildingInfoDto>> getHomeInfo() {
+
+		Long memberId = 1L; // TODO: 2023-09-22 JWT Token으로 대체
+		BuildingInfoDto buildingInfoDto = memberService.getBuildingInfo(memberId);
+
+		return ApiResponse.success(buildingInfoDto, HttpStatus.OK);
+	}
+
+}

--- a/src/main/java/com/livable/server/home/dto/HomeResponse.java
+++ b/src/main/java/com/livable/server/home/dto/HomeResponse.java
@@ -1,0 +1,20 @@
+package com.livable.server.home.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HomeResponse {
+
+	@Getter
+	@AllArgsConstructor
+	public static class BuildingInfoDto {
+
+		private Long buildingId;
+		private String buildingName;
+		private Boolean hasCafeteria;
+	}
+
+}

--- a/src/main/java/com/livable/server/member/domain/MemberErrorCode.java
+++ b/src/main/java/com/livable/server/member/domain/MemberErrorCode.java
@@ -1,0 +1,27 @@
+package com.livable.server.member.domain;
+
+import com.livable.server.core.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MemberErrorCode implements ErrorCode {
+    BUILDING_INFO_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 회원의 빌딩 정보가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/livable/server/member/repository/MemberRepository.java
+++ b/src/main/java/com/livable/server/member/repository/MemberRepository.java
@@ -1,7 +1,20 @@
 package com.livable.server.member.repository;
 
 import com.livable.server.entity.Member;
+import com.livable.server.home.dto.HomeResponse.BuildingInfoDto;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	@Query(value = "select b.id as buildingId, b.name as buildingName, b.hasCafeteria as hasCafeteria" +
+			" from Member m " +
+			" join Company c" +
+			" on m.company = c" +
+			" join fetch Building b " +
+			" on c.building = b" +
+			" where m.id = :memberId")
+	Optional<BuildingInfoDto> findBuildingInfoByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/livable/server/member/service/MemberService.java
+++ b/src/main/java/com/livable/server/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.livable.server.member.service;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.home.dto.HomeResponse.BuildingInfoDto;
+import com.livable.server.member.domain.MemberErrorCode;
+import com.livable.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public BuildingInfoDto getBuildingInfo(Long memberId) {
+		return memberRepository.findBuildingInfoByMemberId(memberId)
+				.orElseThrow(() -> new GlobalRuntimeException(MemberErrorCode.BUILDING_INFO_NOT_EXIST));
+	}
+}

--- a/src/test/java/com/livable/server/home/controller/HomeControllerTest.java
+++ b/src/test/java/com/livable/server/home/controller/HomeControllerTest.java
@@ -1,0 +1,58 @@
+package com.livable.server.home.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.home.dto.HomeResponse.BuildingInfoDto;
+import com.livable.server.member.domain.MemberErrorCode;
+import com.livable.server.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HomeController.class)
+class HomeControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	private MemberService memberService;
+
+	@DisplayName("SUCCESS : 홈 화면에 필요한 정보 응답 컨트롤러 테스트")
+	@Test
+	void getHomeInfoSuccess() throws Exception {
+		// given
+		Long memberId = 1L;
+		given(memberService.getBuildingInfo(memberId))
+				.willReturn(new BuildingInfoDto(1L, "테라 타워", true));
+
+		// when & then
+		mockMvc.perform(get("/api/home"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data['buildingId']").value(1))
+				.andExpect(jsonPath("$.data['buildingName']").value("테라 타워"))
+				.andExpect(jsonPath("$.data['hasCafeteria']").value(true));
+	}
+
+	@DisplayName("FAILED : 홈 화면에 필요한 정보 응답 컨트롤러 테스트 - 조회 실패")
+	@Test
+	void getHomeInfoFailed() throws Exception {
+		// given
+		given(memberService.getBuildingInfo(anyLong()))
+				.willThrow(new GlobalRuntimeException(MemberErrorCode.BUILDING_INFO_NOT_EXIST));
+
+		// when & then
+		mockMvc.perform(get("/api/home"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value(MemberErrorCode.BUILDING_INFO_NOT_EXIST.getMessage()));
+	}
+
+}

--- a/src/test/java/com/livable/server/member/service/MemberServiceTest.java
+++ b/src/test/java/com/livable/server/member/service/MemberServiceTest.java
@@ -1,0 +1,69 @@
+package com.livable.server.member.service;
+
+import static com.livable.server.home.dto.HomeResponse.BuildingInfoDto;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@DisplayName("Success - 홈 화면에 필요한 정보 응답")
+	@Test
+	void getHomeInfoSuccess() {
+		// given
+		Long memberId = 1L;
+		Long buildingId = 1L;
+		String buildingName = "테라 타워";
+		Boolean hasCafeteria = true;
+
+		given(memberRepository.findBuildingInfoByMemberId(memberId))
+				.willReturn(Optional.of(new BuildingInfoDto(buildingId, buildingName, hasCafeteria))
+				);
+
+		// when
+		BuildingInfoDto actual = memberService.getBuildingInfo(memberId);
+
+		// then
+		assertAll(
+			() -> assertEquals(buildingId, actual.getBuildingId()),
+			() -> assertEquals(buildingName, actual.getBuildingName()),
+			() -> assertEquals(hasCafeteria, actual.getHasCafeteria())
+		);
+
+	}
+
+	@DisplayName("FAILED : 홈 화면에 필요한 정보 응답 - 유효하지 않은 정보")
+	@Test
+	void getHomeInfoFailed() {
+		// given
+		Long memberId = 1L;
+
+		// when
+		Mockito.when(memberRepository.findBuildingInfoByMemberId(anyLong()))
+				.thenReturn(Optional.empty());
+
+		// then
+		assertThrows(GlobalRuntimeException.class, () ->
+				memberService.getBuildingInfo(memberId));
+	}
+}


### PR DESCRIPTION
```GET``` /api/home
[홈 화면에 필요한 정보 응답 기능 구현 완료 #42](https://github.com/livable-final/server/issues/42)

- [x] 사용자 식별 값(토큰에서 추출)을 사용하여 building_id를 추출(추후 JWT 토큰으로 대체)

- [x] 건물 이름, 사용자가 소속된 빌딩의 구내식당 여부 조회 후 응답