### PR TITLE
프로젝트 시간 서버와 맞추기 완료

### DIFF
--- a/src/main/java/com/livable/server/LivableServerApplication.java
+++ b/src/main/java/com/livable/server/LivableServerApplication.java
@@ -1,13 +1,25 @@
 package com.livable.server;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
+@Slf4j
 @SpringBootApplication
 public class LivableServerApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(LivableServerApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        log.info("프로젝트 세팅 시간: {}", LocalDateTime.now()); // TODO: 서버 로그 테스트 후 지울예정
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 100
+
+logging:
+  pattern:
+    dateformat: yyyy-MM-dd HH:mm:ss.SSSz,Asia/Seoul


### PR DESCRIPTION
- #94 

<br>

- PostConstructor로 프로젝트 세팅 완료 후 프로젝트의 기본 TimeZone을 Asia/Seoul로 설정했습니다.
  ```java
  @PostConstruct
  public void init() {
      TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
      log.info("프로젝트 세팅 시간: {}", LocalDateTime.now()); // TODO: 서버 로그 테스트 후 지울예정
  }
  ```
  - 로그는 프로젝트 세팅이 정상적으로 되었는지 확인하기 위해서 남겨뒀습니다. 서버에서 확인 후 지울 예정입니다.

- 로그에 찍히는 시간까지 변경하기 위해서 application.yml 설정 파일에 logging 옵션을 추가했습니다.
  ```java
  logging:
    pattern:
      dateformat: yyyy-MM-dd HH:mm:ss.SSSz,Asia/Seoul
  ```