### PR TITLE
최신 리뷰 리스트 응답 기능 개선 완료

### DIFF
--- a/src/main/java/com/livable/server/core/util/ImageSeparator.java
+++ b/src/main/java/com/livable/server/core/util/ImageSeparator.java
@@ -1,0 +1,26 @@
+package com.livable.server.core.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class ImageSeparator {
+
+    public static final String IMAGE_SEPARATOR = ",";
+
+    /**
+     * IMAGE_SEPARATOR로 이어진 이미지 url 문자열을 리스트로 분리하여 반환한다.
+     * @param concatenatedImageUrl
+     * @return 분리된 url 리스트
+     */
+    public List<String> separateConcatenatedImages(String concatenatedImageUrl) {
+        if (Objects.isNull(concatenatedImageUrl)) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(concatenatedImageUrl.split(IMAGE_SEPARATOR));
+    }
+}

--- a/src/main/java/com/livable/server/core/util/S3Uploader.java
+++ b/src/main/java/com/livable/server/core/util/S3Uploader.java
@@ -37,8 +37,9 @@ public class S3Uploader {
 
     public String saveFile(MultipartFile file) throws IOException {
 
-        final String originalFileName = file.getOriginalFilename();
-        assert originalFileName != null;
+        String filename = file.getOriginalFilename();
+        final String originalFileName = filename.replaceAll(ImageSeparator.IMAGE_SEPARATOR, "");
+
         final String fileExtension = getFileExtension(originalFileName);
 
         validationAllowedFileExtension(fileExtension);

--- a/src/main/java/com/livable/server/entity/ReviewImage.java
+++ b/src/main/java/com/livable/server/entity/ReviewImage.java
@@ -1,9 +1,30 @@
 package com.livable.server.entity;
 
+import com.livable.server.review.dto.RestaurantReviewProjection;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
+@SqlResultSetMapping(
+        name = "RestaurantReviewListMapping",
+        classes = @ConstructorResult(
+                targetClass = RestaurantReviewProjection.class,
+                columns = {
+                        @ColumnResult(name = "memberName", type = String.class),
+                        @ColumnResult(name = "restaurantId", type = Long.class),
+                        @ColumnResult(name = "restaurantName", type = String.class),
+                        @ColumnResult(name = "reviewId", type = Long.class),
+                        @ColumnResult(name = "reviewCreatedAt", type = LocalDateTime.class),
+                        @ColumnResult(name = "reviewDescription", type = String.class),
+                        @ColumnResult(name = "reviewTaste", type = String.class),
+                        @ColumnResult(name = "reviewAmount", type = String.class),
+                        @ColumnResult(name = "reviewService", type = String.class),
+                        @ColumnResult(name = "reviewSpeed", type = String.class),
+                        @ColumnResult(name = "images", type = String.class),
+                }
+        )
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/reviews")
@@ -22,14 +24,14 @@ public class RestaurantReviewController {
     private final RestaurantReviewService restaurantReviewService;
 
     @GetMapping("/buildings/{buildingId}")
-    public ResponseEntity<ApiResponse.Success<Page<RestaurantReviewResponse.ListDTO>>> list(
+    public ResponseEntity<ApiResponse.Success<List<RestaurantReviewResponse.ListForBuildingDTO>>> list(
             @PathVariable Long buildingId,
             @PageableDefault Pageable pageable) {
 
-        Page<RestaurantReviewResponse.ListDTO> list =
-                restaurantReviewService.getAllList(buildingId, pageable);
+        List<RestaurantReviewResponse.ListForBuildingDTO> allListForBuilding =
+                restaurantReviewService.getAllListForBuilding(buildingId, pageable);
 
-        return ApiResponse.success(list, HttpStatus.OK);
+        return ApiResponse.success(allListForBuilding, HttpStatus.OK);
     }
 
     @GetMapping("/menus/{menuId}")

--- a/src/main/java/com/livable/server/review/dto/Projection.java
+++ b/src/main/java/com/livable/server/review/dto/Projection.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Projection {
 
     @Getter
@@ -25,6 +24,28 @@ public class Projection {
         private Evaluation reviewService;
         private Evaluation reviewSpeed;
 
-        private String reviewImg;
+        private String images;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RestaurantReviewList {
+
+        private Long memberId;
+        private String memberName;
+
+        private Long restaurantId;
+        private String restaurantName;
+
+        private Long reviewId;
+        private LocalDateTime reviewCreatedAt;
+        private String reviewDescription;
+        private Evaluation reviewTaste;
+        private Evaluation reviewAmount;
+        private Evaluation reviewService;
+        private Evaluation reviewSpeed;
+
+        private String images;
     }
 }

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewProjection.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewProjection.java
@@ -1,0 +1,54 @@
+package com.livable.server.review.dto;
+
+import com.livable.server.entity.Evaluation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RestaurantReviewProjection {
+
+    private String memberName;
+
+    private Long restaurantId;
+    private String restaurantName;
+
+    private Long reviewId;
+    private LocalDateTime reviewCreatedAt;
+    private String reviewDescription;
+    private Evaluation reviewTaste;
+    private Evaluation reviewAmount;
+    private Evaluation reviewService;
+    private Evaluation reviewSpeed;
+
+    private String images;
+
+    public RestaurantReviewProjection(String memberName,
+                                      Long restaurantId,
+                                      String restaurantName,
+                                      Long reviewId,
+                                      LocalDateTime reviewCreatedAt,
+                                      String reviewDescription,
+                                      String reviewTaste,
+                                      String reviewAmount,
+                                      String reviewService,
+                                      String reviewSpeed,
+                                      String images) {
+
+        this.memberName = memberName;
+        this.restaurantId = restaurantId;
+        this.restaurantName = restaurantName;
+        this.reviewId = reviewId;
+        this.reviewCreatedAt = reviewCreatedAt;
+        this.reviewDescription = reviewDescription;
+        this.reviewTaste = Evaluation.valueOf(reviewTaste);
+        this.reviewAmount = Evaluation.valueOf(reviewAmount);
+        this.reviewService = Evaluation.valueOf(reviewService);
+        this.reviewSpeed = Evaluation.valueOf(reviewSpeed);
+        this.images = images;
+    }
+}

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
@@ -36,6 +36,7 @@ public class RestaurantReviewResponse {
                     .restaurantName(restaurantReviewList.getRestaurantName())
                     .reviewId(restaurantReviewList.getReviewId())
                     .reviewCreatedAt(restaurantReviewList.getReviewCreatedAt())
+                    .reviewDescription(restaurantReviewList.getReviewDescription())
                     .reviewTaste(restaurantReviewList.getReviewTaste())
                     .reviewAmount(restaurantReviewList.getReviewAmount())
                     .reviewService(restaurantReviewList.getReviewService())

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
@@ -1,5 +1,6 @@
 package com.livable.server.review.dto;
 
+import com.livable.server.core.util.ImageSeparator;
 import com.livable.server.entity.Evaluation;
 import lombok.*;
 
@@ -11,24 +12,37 @@ public class RestaurantReviewResponse {
 
     @Getter
     @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ListDTO {
+    public static class ListForBuildingDTO {
 
-        private Long reviewId;
-        private LocalDateTime reviewCreatedAt;
-        private String reviewDescription;
+        private final String memberName;
 
-        private Evaluation reviewTaste;
-        private Evaluation reviewAmount;
-        private Evaluation reviewService;
-        private Evaluation reviewSpeed;
+        private final Long restaurantId;
+        private final String restaurantName;
 
-        private Long restaurantId;
-        private String restaurantName;
+        private final Long reviewId;
+        private final LocalDateTime reviewCreatedAt;
+        private final String reviewDescription;
+        private final Evaluation reviewTaste;
+        private final Evaluation reviewAmount;
+        private final Evaluation reviewService;
+        private final Evaluation reviewSpeed;
 
-        private Long memberId;
-        private String memberName;
+        private List<String> reviewImages;
+
+        public static ListForBuildingDTO valueOf(RestaurantReviewProjection restaurantReviewList, ImageSeparator imageSeparator) {
+            return ListForBuildingDTO.builder()
+                    .memberName(restaurantReviewList.getMemberName())
+                    .restaurantId(restaurantReviewList.getRestaurantId())
+                    .restaurantName(restaurantReviewList.getRestaurantName())
+                    .reviewId(restaurantReviewList.getReviewId())
+                    .reviewCreatedAt(restaurantReviewList.getReviewCreatedAt())
+                    .reviewTaste(restaurantReviewList.getReviewTaste())
+                    .reviewAmount(restaurantReviewList.getReviewAmount())
+                    .reviewService(restaurantReviewList.getReviewService())
+                    .reviewSpeed(restaurantReviewList.getReviewSpeed())
+                    .reviewImages(imageSeparator.separateConcatenatedImages(restaurantReviewList.getImages()))
+                    .build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/livable/server/review/repository/MyReviewRepository.java
+++ b/src/main/java/com/livable/server/review/repository/MyReviewRepository.java
@@ -1,16 +1,11 @@
 package com.livable.server.review.repository;
 
-import com.livable.server.review.dto.MyReviewProjection;
+import com.livable.server.entity.Review;
+import com.livable.server.review.repository.querydsl.MyReviewQueryDslRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface MyReviewRepository {
-
-    List<MyReviewProjection> findRestaurantReviewByReviewId(Long reviewId, Long memberId);
-
-    List<MyReviewProjection> findLunchBoxReviewByReviewId(Long reviewId, Long memberId);
-
-    List<MyReviewProjection> findCafeteriaReviewByReviewId(Long reviewId, Long memberId);
+public interface MyReviewRepository
+        extends JpaRepository<Review, Long>, MyReviewQueryDslRepository {
 }

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewProjectionRepository.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewProjectionRepository.java
@@ -1,0 +1,59 @@
+package com.livable.server.review.repository;
+
+import com.livable.server.core.util.ImageSeparator;
+import com.livable.server.review.dto.RestaurantReviewProjection;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.List;
+
+@Repository
+public class RestaurantReviewProjectionRepository {
+
+    private static final String FIND_RESTAURANT_REVIEW_QUERY;
+
+    static {
+        FIND_RESTAURANT_REVIEW_QUERY = "SELECT " +
+                "m.name AS memberName, " +
+                "res.id AS restaurantId, " +
+                "res.name AS restaurantName, " +
+                "r.id AS reviewId, " +
+                "r.created_at AS reviewCreatedAt, " +
+                "r.description AS reviewDescription, " +
+                "rr.taste AS reviewTaste, " +
+                "rr.amount AS reviewAmount, " +
+                "rr.service AS reviewService, " +
+                "rr.speed AS reviewSpeed, " +
+                "GROUP_CONCAT(ri.url SEPARATOR :separator) AS images " +
+                "FROM review r " +
+                "INNER JOIN restaurant_review rr ON r.id = rr.id " +
+                "INNER JOIN member m ON r.member_id = m.id " +
+                "INNER JOIN restaurant res ON rr.restaurant_id = res.id " +
+                "LEFT JOIN review_image ri ON ri.review_id = r.id " +
+                "WHERE rr.restaurant_id IN " +
+                "(SELECT restaurant_id " +
+                "FROM building_restaurant_map " +
+                "WHERE building_id = :buildingId) " +
+                "GROUP BY r.id, rr.id, m.id, res.id " +
+                "ORDER BY r.created_at DESC " +
+                "LIMIT :limit " +
+                "OFFSET :offset";
+    }
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public List<RestaurantReviewProjection> findRestaurantReviewProjectionByBuildingId(Long buildingId, Pageable pageable) {
+
+        Query query = entityManager.createNativeQuery(FIND_RESTAURANT_REVIEW_QUERY, "RestaurantReviewListMapping")
+                .setParameter("separator", ImageSeparator.IMAGE_SEPARATOR)
+                .setParameter("buildingId", buildingId)
+                .setParameter("limit", pageable.getPageSize())
+                .setParameter("offset", pageable.getOffset());
+
+        return (List<RestaurantReviewProjection>) query.getResultList();
+    }
+}

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewRepository.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewRepository.java
@@ -1,8 +1,11 @@
 package com.livable.server.review.repository;
 
 import com.livable.server.entity.RestaurantReview;
+import com.livable.server.review.repository.querydsl.RestaurantReviewQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long>, RestaurantReviewCustomRepository {
-
+@Repository
+public interface RestaurantReviewRepository
+        extends JpaRepository<RestaurantReview, Long>, RestaurantReviewQueryDslRepository {
 }

--- a/src/main/java/com/livable/server/review/repository/querydsl/MyReviewQueryDslRepository.java
+++ b/src/main/java/com/livable/server/review/repository/querydsl/MyReviewQueryDslRepository.java
@@ -1,0 +1,16 @@
+package com.livable.server.review.repository.querydsl;
+
+import com.livable.server.review.dto.MyReviewProjection;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MyReviewQueryDslRepository {
+
+    List<MyReviewProjection> findRestaurantReviewByReviewId(Long reviewId, Long memberId);
+
+    List<MyReviewProjection> findLunchBoxReviewByReviewId(Long reviewId, Long memberId);
+
+    List<MyReviewProjection> findCafeteriaReviewByReviewId(Long reviewId, Long memberId);
+}

--- a/src/main/java/com/livable/server/review/repository/querydsl/MyReviewQueryDslRepositoryImpl.java
+++ b/src/main/java/com/livable/server/review/repository/querydsl/MyReviewQueryDslRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.livable.server.review.repository;
+package com.livable.server.review.repository.querydsl;
 
 import com.livable.server.review.dto.MyReviewProjection;
 import com.querydsl.core.types.Projections;
@@ -17,7 +17,7 @@ import static com.livable.server.entity.QReviewImage.reviewImage;
 
 @Component
 @RequiredArgsConstructor
-public class MyReviewRepositoryImpl implements MyReviewRepository {
+public class MyReviewQueryDslRepositoryImpl implements MyReviewQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/src/main/java/com/livable/server/review/repository/querydsl/RestaurantReviewQueryDslRepository.java
+++ b/src/main/java/com/livable/server/review/repository/querydsl/RestaurantReviewQueryDslRepository.java
@@ -1,4 +1,4 @@
-package com.livable.server.review.repository;
+package com.livable.server.review.repository.querydsl;
 
 import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
@@ -7,9 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-public interface RestaurantReviewCustomRepository {
-
-    Page<RestaurantReviewResponse.ListDTO> findRestaurantReviewByBuildingId(Long buildingId, Pageable pageable);
+public interface RestaurantReviewQueryDslRepository {
 
     Page<RestaurantReviewResponse.ListForMenuDTO> findRestaurantReviewByMenuId(Long menuId, Pageable pageable);
 

--- a/src/main/java/com/livable/server/review/repository/querydsl/RestaurantReviewQueryDslRepositoryImpl.java
+++ b/src/main/java/com/livable/server/review/repository/querydsl/RestaurantReviewQueryDslRepositoryImpl.java
@@ -1,6 +1,5 @@
-package com.livable.server.review.repository;
+package com.livable.server.review.repository.querydsl;
 
-import com.livable.server.entity.*;
 import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
 import com.querydsl.core.types.Projections;
@@ -22,54 +21,9 @@ import static com.livable.server.entity.QReviewImage.reviewImage;
 import static com.livable.server.entity.QReviewMenuMap.reviewMenuMap;
 
 @RequiredArgsConstructor
-public class RestaurantReviewCustomRepositoryImpl implements RestaurantReviewCustomRepository {
+public class RestaurantReviewQueryDslRepositoryImpl implements RestaurantReviewQueryDslRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    @Override
-    public Page<RestaurantReviewResponse.ListDTO> findRestaurantReviewByBuildingId(Long buildingId, Pageable pageable) {
-
-        final QReview review = QReview.review;
-        final QRestaurantReview restaurantReview = QRestaurantReview.restaurantReview;
-        final QMember member = QMember.member;
-        final QRestaurant restaurant = QRestaurant.restaurant;
-        final QBuildingRestaurantMap buildingRestaurantMap = QBuildingRestaurantMap.buildingRestaurantMap;
-
-        JPAQuery<RestaurantReviewResponse.ListDTO> query = queryFactory
-                .select(Projections.constructor(RestaurantReviewResponse.ListDTO.class,
-                        review.id,
-                        review.createdAt,
-                        review.description,
-                        restaurantReview.taste,
-                        restaurantReview.amount,
-                        restaurantReview.service,
-                        restaurantReview.speed,
-                        restaurantReview.restaurant.id,
-                        restaurant.name,
-                        review.member.id,
-                        member.name
-                ))
-                .from(review)
-                .innerJoin(restaurantReview).on(review.id.eq(restaurantReview.id))
-                .innerJoin(member).on(review.member.id.eq(member.id))
-                .innerJoin(restaurant).on(restaurantReview.restaurant.id.eq(restaurant.id))
-                .where(restaurantReview.restaurant.id.in(
-                        JPAExpressions
-                                .select(buildingRestaurantMap.restaurant.id)
-                                .from(buildingRestaurantMap)
-                                .where(buildingRestaurantMap.building.id.eq(buildingId))
-                ))
-                .orderBy(review.createdAt.desc());
-
-        List<RestaurantReviewResponse.ListDTO> content = query
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetchJoin().fetch();
-
-        long total = query.fetchCount();
-
-        return new PageImpl<>(content, pageable, total);
-    }
 
     @Override
     public Page<RestaurantReviewResponse.ListForMenuDTO> findRestaurantReviewByMenuId(Long menuId, Pageable pageable) {

--- a/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
+++ b/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
@@ -1,10 +1,12 @@
 package com.livable.server.review.service;
 
-import com.livable.server.core.exception.ErrorCode;
 import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.core.util.ImageSeparator;
 import com.livable.server.review.domain.MyReviewErrorCode;
 import com.livable.server.review.dto.Projection;
+import com.livable.server.review.dto.RestaurantReviewProjection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
+import com.livable.server.review.repository.RestaurantReviewProjectionRepository;
 import com.livable.server.review.repository.RestaurantReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,10 +22,19 @@ import java.util.stream.Collectors;
 public class RestaurantReviewService {
 
     private final RestaurantReviewRepository restaurantReviewRepository;
+    private final RestaurantReviewProjectionRepository restaurantProjectionRepository;
+    private final ImageSeparator imageSeparator;
 
     @Transactional(readOnly = true)
-    public Page<RestaurantReviewResponse.ListDTO> getAllList(Long buildingId, Pageable pageable) {
-        return restaurantReviewRepository.findRestaurantReviewByBuildingId(buildingId, pageable);
+    public List<RestaurantReviewResponse.ListForBuildingDTO> getAllListForBuilding(Long buildingId, Pageable pageable) {
+
+        List<RestaurantReviewProjection> restaurantReviewLists =
+                restaurantProjectionRepository.findRestaurantReviewProjectionByBuildingId(buildingId, pageable);
+
+        return restaurantReviewLists.stream()
+                .map(restaurantReviewList ->
+                        RestaurantReviewResponse.ListForBuildingDTO.valueOf(restaurantReviewList, imageSeparator))
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -43,7 +54,7 @@ public class RestaurantReviewService {
 
         Projection.RestaurantReview restaurantReview = restaurantReviews.get(0);
         List<String> reviewImages = restaurantReviews.stream()
-                .map(Projection.RestaurantReview::getReviewImg)
+                .map(Projection.RestaurantReview::getImages)
                 .collect(Collectors.toList());
 
         return RestaurantReviewResponse.DetailDTO.from(restaurantReview, reviewImages);

--- a/src/test/java/com/livable/server/core/util/ImageSeparatorTest.java
+++ b/src/test/java/com/livable/server/core/util/ImageSeparatorTest.java
@@ -1,0 +1,62 @@
+package com.livable.server.core.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class ImageSeparatorTest {
+
+    private ImageSeparator imageSeparator;
+
+    @BeforeEach
+    void setUp() {
+        imageSeparator = new ImageSeparator();
+    }
+
+    @Test
+    void success_Test_GivenMultipleUrls() {
+        // Given
+        String images = "https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95%ED%83%95.jpg,https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95.jpg";
+
+        // When
+        List<String> actual = imageSeparator.separateConcatenatedImages(images);
+
+        // Then
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(2, actual.size()),
+                () -> Assertions.assertEquals("https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95%ED%83%95.jpg", actual.get(0)),
+                () -> Assertions.assertEquals("https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95.jpg", actual.get(1))
+        );
+    }
+
+    @Test
+    void success_Test_GivenSingleUrls() {
+        // Given
+        String images = "https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95%ED%83%95.jpg";
+
+        // When
+        List<String> actual = imageSeparator.separateConcatenatedImages(images);
+
+        // Then
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(1, actual.size()),
+                () -> Assertions.assertEquals("https://livable-final.s3.ap-northeast-2.amazonaws.com/%EB%A7%88%EB%9D%BC%ED%83%95%ED%83%95.jpg", actual.get(0))
+        );
+    }
+
+    @Test
+    void success_Test_GivenNull() {
+        // Given
+        String images = null;
+
+        // When
+        List<String> actual = imageSeparator.separateConcatenatedImages(images);
+
+        // Then
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(actual.isEmpty())
+        );
+    }
+}

--- a/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
@@ -41,24 +41,24 @@ class RestaurantReviewControllerTest {
             // Given
             String uri = "/api/reviews/buildings/1";
 
-            List<RestaurantReviewResponse.ListDTO> mockList = List.of(
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(1L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(2L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(3L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(4L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(5L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(6L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(7L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(8L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(9L).build(),
-                    RestaurantReviewResponse.ListDTO.builder().reviewId(10L).build()
+            List<RestaurantReviewResponse.ListForBuildingDTO> mockList = List.of(
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(1L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(2L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(3L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(4L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(5L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(6L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(7L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(8L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(9L).build(),
+                    RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(10L).build()
             );
             Pageable pageable = PageRequest.of(0, 10);
-            Page<RestaurantReviewResponse.ListDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
 
-            Mockito.when(restaurantReviewService
-                    .getAllList(ArgumentMatchers.anyLong(), ArgumentMatchers.any(Pageable.class)))
-                    .thenReturn(mockPage);
+            Mockito.when(restaurantReviewService.getAllListForBuilding(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(Pageable.class))
+            ).thenReturn(mockList);
 
             // When
             // Then
@@ -66,8 +66,8 @@ class RestaurantReviewControllerTest {
                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(MockMvcResultMatchers.status().isOk())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists())
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").isArray())
-                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.content.length()").value(10));
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(10));
         }
     }
 

--- a/src/test/java/com/livable/server/review/service/MyReviewServiceTest.java
+++ b/src/test/java/com/livable/server/review/service/MyReviewServiceTest.java
@@ -18,8 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @ExtendWith(MockitoExtension.class)
 class MyReviewServiceTest {
 

--- a/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
+++ b/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
@@ -1,8 +1,11 @@
 package com.livable.server.review.service;
 
 import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.core.util.ImageSeparator;
 import com.livable.server.review.dto.Projection;
+import com.livable.server.review.dto.RestaurantReviewProjection;
 import com.livable.server.review.dto.RestaurantReviewResponse;
+import com.livable.server.review.repository.RestaurantReviewProjectionRepository;
 import com.livable.server.review.repository.RestaurantReviewRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +25,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.livable.server.review.dto.RestaurantReviewResponse.ListDTO;
+import static com.livable.server.review.dto.RestaurantReviewResponse.*;
 import static com.livable.server.review.dto.RestaurantReviewResponse.ListForMenuDTO;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,12 +34,18 @@ class RestaurantReviewServiceTest {
     @Mock
     private RestaurantReviewRepository restaurantReviewRepository;
 
+    @Mock
+    private RestaurantReviewProjectionRepository restaurantReviewProjectionRepository;
+
+    @Mock
+    private ImageSeparator imageSeparator;
+
     @InjectMocks
     private RestaurantReviewService restaurantReviewService;
 
     @Nested
     @DisplayName("레스토랑 리뷰 리스트 서비스 단위 테스트")
-    class list {
+    class listForBuilding {
 
         @DisplayName("성공")
         @Test
@@ -44,34 +53,35 @@ class RestaurantReviewServiceTest {
             // Given
             Long buildingId = 1L;
 
-            List<ListDTO> mockList = List.of(
-                    ListDTO.builder().reviewId(1L).build(),
-                    ListDTO.builder().reviewId(2L).build(),
-                    ListDTO.builder().reviewId(3L).build(),
-                    ListDTO.builder().reviewId(4L).build(),
-                    ListDTO.builder().reviewId(5L).build(),
-                    ListDTO.builder().reviewId(6L).build(),
-                    ListDTO.builder().reviewId(7L).build(),
-                    ListDTO.builder().reviewId(8L).build(),
-                    ListDTO.builder().reviewId(9L).build(),
-                    ListDTO.builder().reviewId(10L).build()
+            List<RestaurantReviewProjection> mockList = List.of(
+                    RestaurantReviewProjection.builder().reviewId(1L).build(),
+                    RestaurantReviewProjection.builder().reviewId(2L).build(),
+                    RestaurantReviewProjection.builder().reviewId(3L).build(),
+                    RestaurantReviewProjection.builder().reviewId(4L).build(),
+                    RestaurantReviewProjection.builder().reviewId(5L).build(),
+                    RestaurantReviewProjection.builder().reviewId(6L).build(),
+                    RestaurantReviewProjection.builder().reviewId(7L).build(),
+                    RestaurantReviewProjection.builder().reviewId(8L).build(),
+                    RestaurantReviewProjection.builder().reviewId(9L).build(),
+                    RestaurantReviewProjection.builder().reviewId(10L).build()
             );
             Pageable pageable = PageRequest.of(0, 10);
-            Page<ListDTO> mockPage = new PageImpl<>(mockList, pageable, 1);
 
-            Mockito.when(restaurantReviewRepository.findRestaurantReviewByBuildingId(
+            Mockito.when(imageSeparator.separateConcatenatedImages(null))
+                    .thenReturn(new ArrayList<>());
+
+            Mockito.when(restaurantReviewProjectionRepository.findRestaurantReviewProjectionByBuildingId(
                     ArgumentMatchers.anyLong(),
                     ArgumentMatchers.any(Pageable.class)
-            )).thenReturn(mockPage);
+            )).thenReturn(mockList);
 
             // When
-            Page<ListDTO> actual =
-                    restaurantReviewService.getAllList(buildingId, pageable);
+            List<RestaurantReviewResponse.ListForBuildingDTO> actual =
+                    restaurantReviewService.getAllListForBuilding(buildingId, pageable);
 
             // Then
             Assertions.assertAll(
-                    () -> Assertions.assertEquals(10, actual.getSize()),
-                    () -> Assertions.assertEquals(1, actual.getTotalPages())
+                    () -> Assertions.assertEquals(10, actual.size())
             );
         }
     }
@@ -130,7 +140,7 @@ class RestaurantReviewServiceTest {
 
             List<Projection.RestaurantReview> mockResult = List.of(
                     Projection.RestaurantReview.builder()
-                            .reviewImg("TestImages")
+                            .images("TestImages")
                             .reviewDescription("TestDescription")
                             .build()
             );
@@ -138,7 +148,7 @@ class RestaurantReviewServiceTest {
             Mockito.when(restaurantReviewRepository.findRestaurantReviewById(ArgumentMatchers.anyLong()))
                     .thenReturn(mockResult);
             // When
-            RestaurantReviewResponse.DetailDTO actual = restaurantReviewService.getDetail(reviewId);
+            DetailDTO actual = restaurantReviewService.getDetail(reviewId);
 
             // Then
             Assertions.assertAll(
@@ -155,11 +165,11 @@ class RestaurantReviewServiceTest {
 
             List<Projection.RestaurantReview> mockResult = List.of(
                     Projection.RestaurantReview.builder()
-                            .reviewImg("TestImage1")
+                            .images("TestImage1")
                             .reviewDescription("TestDescription")
                             .build(),
                     Projection.RestaurantReview.builder()
-                            .reviewImg("TestImage2")
+                            .images("TestImage2")
                             .reviewDescription("TestDescription")
                             .build()
             );
@@ -167,7 +177,7 @@ class RestaurantReviewServiceTest {
             Mockito.when(restaurantReviewRepository.findRestaurantReviewById(ArgumentMatchers.anyLong()))
                     .thenReturn(mockResult);
             // When
-            RestaurantReviewResponse.DetailDTO actual = restaurantReviewService.getDetail(reviewId);
+            DetailDTO actual = restaurantReviewService.getDetail(reviewId);
 
             // Then
             Assertions.assertAll(


### PR DESCRIPTION
기존의 기능의 응답에서 restaurant_id 컬럼을 추가해서 응답할 수 있도록 변경한다.
- #86 
- #26 기능 개선

### 변경이유
최신 리뷰 리스트 응답에서 restaurant_id만 추가된다면
레스토랑 리뷰 상세보기 페이지에서 상세정보에 대한 데이터를 요청할 필요가 없어진다.
추가로 레스토랑 리뷰 상세보기 페이지에서 함께 보여져야 할 데이터를 가져오는 식별자가 된다.

### 변경사항
- 기존의 기능애서 리뷰 이미지를 가져오는 로직이 추가됨.
- 기존의 기능에서 restaurant_id 컬럼을 가져오는 로직이 추가됨.
- 이미지 업로드 시 파일명에 구분자(',')가 있다면 삭제하는 로직이 추가됨.
- 이미지를 병합하여 문자열로 가져오는 로직이 추가됨.
- 병합된 이미지를 구분자를 통해 분리하여 리스트로 반환하는 기능이 추가됨 

### Issue
특정 DBMS에 종속적이지 않으려고 여러 이미지를 가져와 리스트로 추출하는 작업은 
애플리케이션 코드 레벨에서 진행되고 있음. 
추가로 해당 기능은 페이징까지 처리해야 함.

따라서 해당 작업을 수행하려면 리뷰의 쿼리 검색 결과를
List<List<ReviewProjection>>으로 불러와야 하는데 이게 쿼리 한번으로 가능한지?
페이징은 가능한지 모르겠다.

여러 조인 결과와 함께 oneToMany인 테이블의 특정 컬럼들을 불러와야 하는 작업을 해야해 근데 페이징까지 해야해
현재 방식으로는 해결 방법을 찾지 못하겠으니
GROUP_CONCAT을 사용하되 이미지를 저장할 때 부수적인 작업이 필요하다.
예를들어 그룹핑의 결과들을 특정 구분자`,`를 통해 결합한다면 
이미지 저장 작업에서 구분자로 사용되는 문자열을 제거하는 작업이 필요할 것이다.

2023-09-23 05:54
```SQL
SELECT
    r.id AS review_id,
    r.created_at AS review_created_at,
    r.description AS review_description,
    r.member_id AS member_id,
    rr.restaurant_id AS restaurant_id,
    rr.taste AS review_taste,
    rr.amount AS review_amount,
    rr.service AS review_service,
    rr.speed AS review_speed,
    m.name AS member_name,
    res.name AS restaurant_name,
    GROUP_CONCAT(ri.url) AS urls
FROM review r
INNER JOIN restaurant_review rr ON r.id = rr.id
INNER JOIN member m ON r.member_id = m.id
INNER JOIN restaurant res ON rr.restaurant_id = res.id
LEFT JOIN review_image ri ON ri.review_id = r.id
WHERE rr.restaurant_id 
IN (
    SELECT restaurant_id
    FROM building_restaurant_map
    WHERE building_id = 1
)
GROUP BY r.id, rr.id, m.id, res.id
ORDER BY r.created_at DESC
LIMIT 10
OFFSET 0;
```
결국 네이티브 쿼리를 사용하고 DTO에 결과를 매핑했다.
JPA 영속성 컨텍스트의 사용은 하나도 없고, 
오히려 쿼리 결과 매핑은 번거로워지고 코드 가독성은 떨어졌다.
이래서 마이바티스를 섞어쓰나보다

resolved: #86 