### PR TITLE
방문증 인증 callback 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/invitation/controller/InvitationValidationController.java
+++ b/src/main/java/com/livable/server/invitation/controller/InvitationValidationController.java
@@ -1,0 +1,32 @@
+package com.livable.server.invitation.controller;
+
+import com.livable.server.invitation.service.InvitationValidationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@Controller
+public class InvitationValidationController {
+
+    private static final String visitationPageUrl = "https://livable.vercel.app/invitation/view";
+
+    private final InvitationValidationService invitationValidationService;
+
+    @GetMapping("api/invitation/callback")
+    public String validateVisitor(@RequestParam String token, HttpServletResponse response) {
+
+        invitationValidationService.validateVisitor(token);
+
+        response.setHeader("Authorization", createBearerToken(token));
+
+        return "redirect:" + visitationPageUrl;
+    }
+
+    private String createBearerToken(String token) {
+        return "Bearer " + token;
+    }
+}

--- a/src/main/java/com/livable/server/invitation/service/InvitationValidationService.java
+++ b/src/main/java/com/livable/server/invitation/service/InvitationValidationService.java
@@ -1,0 +1,25 @@
+package com.livable.server.invitation.service;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.core.util.ActorType;
+import com.livable.server.core.util.JwtTokenProvider;
+import com.livable.server.member.domain.MemberErrorCode;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class InvitationValidationService {
+
+    private final JwtTokenProvider tokenProvider;
+
+    public void validateVisitor(String token) {
+        Claims claims = tokenProvider.parseClaims(token);
+
+        String actorType = claims.get("actorType", String.class);
+        if (!actorType.equals(ActorType.VISITOR.name())) {
+            throw new GlobalRuntimeException(MemberErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/test/java/com/livable/server/invitation/controller/InvitationValidationControllerTest.java
+++ b/src/test/java/com/livable/server/invitation/controller/InvitationValidationControllerTest.java
@@ -1,0 +1,53 @@
+package com.livable.server.invitation.controller;
+
+import com.livable.server.core.util.ActorType;
+import com.livable.server.core.util.JwtTokenProvider;
+import com.livable.server.core.util.TestConfig;
+import com.livable.server.invitation.service.InvitationValidationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Date;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestConfig.class)
+@WebMvcTest(InvitationValidationController.class)
+class InvitationValidationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    JwtTokenProvider tokenProvider;
+
+    @MockBean
+    InvitationValidationService invitationValidationService;
+
+    @DisplayName("[성공] 방문자 Callback - 정상 응답")
+    @Test
+    void validateVisitorSuccess_01() throws Exception {
+        // Given
+        String token = tokenProvider.createActorToken(ActorType.VISITOR, 1L, new Date(Long.MAX_VALUE));
+
+        // When
+        ResultActions resultActions = mockMvc
+                .perform(
+                        get("/api/invitation/callback")
+                                .param("token", token)
+                );
+
+        // Then
+        resultActions
+                .andExpect(status().isFound())
+                .andExpect(header().string("Authorization", "Bearer " + token));
+    }
+}

--- a/src/test/java/com/livable/server/invitation/service/InvitationValidationServiceTest.java
+++ b/src/test/java/com/livable/server/invitation/service/InvitationValidationServiceTest.java
@@ -1,0 +1,43 @@
+package com.livable.server.invitation.service;
+
+import com.livable.server.core.exception.GlobalRuntimeException;
+import com.livable.server.core.util.JwtTokenProvider;
+import com.livable.server.member.domain.MemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class InvitationValidationServiceTest {
+
+    @Mock
+    JwtTokenProvider tokenProvider;
+
+    @InjectMocks
+    InvitationValidationService invitationValidationService;
+
+    @DisplayName("[실패] 방문자 callback - 잘못된 토큰으로 요청한 경우")
+    @Test
+    void validateVisitorFail_01() {
+        // Given
+        String token = "token";
+        given(tokenProvider.parseClaims(anyString()))
+                .willThrow(new GlobalRuntimeException(MemberErrorCode.INVALID_TOKEN));
+
+        // When
+        GlobalRuntimeException exception = assertThrows(GlobalRuntimeException.class,
+                () -> invitationValidationService.validateVisitor(token));
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.INVALID_TOKEN);
+    }
+}


### PR DESCRIPTION
- #97 

<br>

### 프로세스
1. 방문자가 알림톡으로 받은 링크를 클릭한다.
2. 방문자가 링크를 클릭하면 `/api/invitation/callback?token=${visitor_token}`으로 `GET` 요청을 보낸다.
3. 서버는 해당 토큰을 확인하여 방문자 토큰이 맞는지 여부를 확인한다. (유효한 토큰인지도 확인)
4. 만약 3번이 통과 되지 않으면 `401 UNAUTHORIZED`를 응답한다.
5. 만약 3번이 통과 되면 `200 OK`를 응답한다.
6. 이때 Response Header의 `Authorization`에 `{visitor_token}`을 담아서 클라이언트의 방문 페이지 URL로 **Redirect**를 시킨다.

<br>

### 알아야 하는 정보
1. 클라이언트의 배포된 도메인 (바뀌지 않는 값으로...)
2. 방문 페이지 URL

<br>
