### PR TITLE
특정 음식점에 대한 리뷰 리스트 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/RestaurantReviewController.java
@@ -45,6 +45,17 @@ public class RestaurantReviewController {
         return ApiResponse.success(allListForMenu, HttpStatus.OK);
     }
 
+    @GetMapping("/restaurants/{restaurantId}")
+    public ResponseEntity<ApiResponse.Success<List<RestaurantReviewResponse.ListForRestaurantDTO>>> listForRestaurant(
+            @PathVariable Long restaurantId,
+            @PageableDefault Pageable pageable) {
+
+        List<RestaurantReviewResponse.ListForRestaurantDTO> allListForRestaurant =
+                restaurantReviewService.getAllListForRestaurant(restaurantId, pageable);
+
+        return ApiResponse.success(allListForRestaurant, HttpStatus.OK);
+    }
+
     @GetMapping("/{reviewId}")
     public ResponseEntity<ApiResponse.Success<RestaurantReviewResponse.DetailDTO>> detail(@PathVariable Long reviewId) {
 

--- a/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/RestaurantReviewResponse.java
@@ -48,6 +48,42 @@ public class RestaurantReviewResponse {
 
     @Getter
     @Builder
+    public static class ListForRestaurantDTO {
+
+        private final String memberName;
+
+        private final Long restaurantId;
+        private final String restaurantName;
+
+        private final Long reviewId;
+        private final LocalDateTime reviewCreatedAt;
+        private final String reviewDescription;
+        private final Evaluation reviewTaste;
+        private final Evaluation reviewAmount;
+        private final Evaluation reviewService;
+        private final Evaluation reviewSpeed;
+
+        private List<String> reviewImages;
+
+        public static ListForRestaurantDTO valueOf(RestaurantReviewProjection restaurantReviewList, ImageSeparator imageSeparator) {
+            return ListForRestaurantDTO.builder()
+                    .memberName(restaurantReviewList.getMemberName())
+                    .restaurantId(restaurantReviewList.getRestaurantId())
+                    .restaurantName(restaurantReviewList.getRestaurantName())
+                    .reviewId(restaurantReviewList.getReviewId())
+                    .reviewCreatedAt(restaurantReviewList.getReviewCreatedAt())
+                    .reviewDescription(restaurantReviewList.getReviewDescription())
+                    .reviewTaste(restaurantReviewList.getReviewTaste())
+                    .reviewAmount(restaurantReviewList.getReviewAmount())
+                    .reviewService(restaurantReviewList.getReviewService())
+                    .reviewSpeed(restaurantReviewList.getReviewSpeed())
+                    .reviewImages(imageSeparator.separateConcatenatedImages(restaurantReviewList.getImages()))
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ListForMenuDTO {

--- a/src/main/java/com/livable/server/review/repository/RestaurantReviewProjectionRepository.java
+++ b/src/main/java/com/livable/server/review/repository/RestaurantReviewProjectionRepository.java
@@ -13,10 +13,12 @@ import java.util.List;
 @Repository
 public class RestaurantReviewProjectionRepository {
 
-    private static final String FIND_RESTAURANT_REVIEW_QUERY;
+    private static final String FIND_RESTAURANT_REVIEW_BY_BUILDING_ID_QUERY;
+    private static final String FIND_RESTAURANT_REVIEW_BY_RESTAURANT_ID_QUERY;
+
 
     static {
-        FIND_RESTAURANT_REVIEW_QUERY = "SELECT " +
+        FIND_RESTAURANT_REVIEW_BY_BUILDING_ID_QUERY = "SELECT " +
                 "m.name AS memberName, " +
                 "res.id AS restaurantId, " +
                 "res.name AS restaurantName, " +
@@ -41,6 +43,29 @@ public class RestaurantReviewProjectionRepository {
                 "ORDER BY r.created_at DESC " +
                 "LIMIT :limit " +
                 "OFFSET :offset";
+
+        FIND_RESTAURANT_REVIEW_BY_RESTAURANT_ID_QUERY = "SELECT " +
+                "m.name AS memberName, " +
+                "res.id AS restaurantId, " +
+                "res.name AS restaurantName, " +
+                "r.id AS reviewId, " +
+                "r.created_at AS reviewCreatedAt, " +
+                "r.description AS reviewDescription, " +
+                "rr.taste AS reviewTaste, " +
+                "rr.amount AS reviewAmount, " +
+                "rr.service AS reviewService, " +
+                "rr.speed AS reviewSpeed, " +
+                "GROUP_CONCAT(ri.url SEPARATOR :separator) AS images " +
+                "FROM review r " +
+                "INNER JOIN restaurant_review rr ON r.id = rr.id " +
+                "INNER JOIN member m ON r.member_id = m.id " +
+                "INNER JOIN restaurant res ON rr.restaurant_id = res.id " +
+                "LEFT JOIN review_image ri ON ri.review_id = r.id " +
+                "WHERE rr.restaurant_id = :restaurantId " +
+                "GROUP BY r.id, rr.id, m.id, res.id " +
+                "ORDER BY r.created_at DESC " +
+                "LIMIT :limit " +
+                "OFFSET :offset";
     }
 
     @PersistenceContext
@@ -48,9 +73,20 @@ public class RestaurantReviewProjectionRepository {
 
     public List<RestaurantReviewProjection> findRestaurantReviewProjectionByBuildingId(Long buildingId, Pageable pageable) {
 
-        Query query = entityManager.createNativeQuery(FIND_RESTAURANT_REVIEW_QUERY, "RestaurantReviewListMapping")
+        Query query = entityManager.createNativeQuery(FIND_RESTAURANT_REVIEW_BY_BUILDING_ID_QUERY, "RestaurantReviewListMapping")
                 .setParameter("separator", ImageSeparator.IMAGE_SEPARATOR)
                 .setParameter("buildingId", buildingId)
+                .setParameter("limit", pageable.getPageSize())
+                .setParameter("offset", pageable.getOffset());
+
+        return (List<RestaurantReviewProjection>) query.getResultList();
+    }
+
+    public List<RestaurantReviewProjection> findRestaurantReviewProjectionByRestaurantId(Long restaurantId, Pageable pageable) {
+
+        Query query = entityManager.createNativeQuery(FIND_RESTAURANT_REVIEW_BY_RESTAURANT_ID_QUERY, "RestaurantReviewListMapping")
+                .setParameter("separator", ImageSeparator.IMAGE_SEPARATOR)
+                .setParameter("restaurantId", restaurantId)
                 .setParameter("limit", pageable.getPageSize())
                 .setParameter("offset", pageable.getOffset());
 

--- a/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
+++ b/src/main/java/com/livable/server/review/service/RestaurantReviewService.java
@@ -38,6 +38,18 @@ public class RestaurantReviewService {
     }
 
     @Transactional(readOnly = true)
+    public List<RestaurantReviewResponse.ListForRestaurantDTO> getAllListForRestaurant(Long restaurantId, Pageable pageable) {
+
+        List<RestaurantReviewProjection> reviewProjections =
+                restaurantProjectionRepository.findRestaurantReviewProjectionByRestaurantId(restaurantId, pageable);
+
+        return reviewProjections.stream()
+                .map(reviewProjection ->
+                        RestaurantReviewResponse.ListForRestaurantDTO.valueOf(reviewProjection, imageSeparator))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
     public Page<RestaurantReviewResponse.ListForMenuDTO> getAllListForMenu(Long menuId, Pageable pageable) {
         return restaurantReviewRepository.findRestaurantReviewByMenuId(menuId, pageable);
     }

--- a/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
+++ b/src/test/java/com/livable/server/review/controller/RestaurantReviewControllerTest.java
@@ -1,7 +1,6 @@
 package com.livable.server.review.controller;
 
 import com.livable.server.core.util.TestConfig;
-import com.livable.server.review.dto.MyReviewResponse;
 import com.livable.server.review.dto.RestaurantReviewResponse;
 import com.livable.server.review.service.RestaurantReviewService;
 import org.junit.jupiter.api.DisplayName;
@@ -56,7 +55,6 @@ class RestaurantReviewControllerTest {
                     RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(9L).build(),
                     RestaurantReviewResponse.ListForBuildingDTO.builder().reviewId(10L).build()
             );
-            Pageable pageable = PageRequest.of(0, 10);
 
             Mockito.when(restaurantReviewService.getAllListForBuilding(
                     ArgumentMatchers.anyLong(),
@@ -66,7 +64,46 @@ class RestaurantReviewControllerTest {
             // When
             // Then
             mockMvc.perform(MockMvcRequestBuilders.get(uri)
-                    .accept(MediaType.APPLICATION_JSON))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(10));
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 음식점에 대한 레스토랑 리뷰 리스트 컨트롤러 단위 테스트")
+    class listForRestaurant {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() throws Exception {
+            // Given
+            String uri = "/api/reviews/restaurants/1";
+
+            List<RestaurantReviewResponse.ListForRestaurantDTO> mockList = List.of(
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(1L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(2L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(3L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(4L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(6L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(5L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(7L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(8L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(9L).build(),
+                    RestaurantReviewResponse.ListForRestaurantDTO.builder().reviewId(10L).build()
+            );
+
+            Mockito.when(restaurantReviewService.getAllListForRestaurant(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(Pageable.class)
+            )).thenReturn(mockList);
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.get(uri)
+                            .accept(MediaType.APPLICATION_JSON))
                     .andExpect(MockMvcResultMatchers.status().isOk())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data").exists())
                     .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())

--- a/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
+++ b/src/test/java/com/livable/server/review/service/RestaurantReviewServiceTest.java
@@ -87,6 +87,49 @@ class RestaurantReviewServiceTest {
     }
 
     @Nested
+    @DisplayName("특정 음식점에 대한 리뷰 리스트 서비스 단위 테스트")
+    class listForRestaurant {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() {
+            // Given
+            Long restaurantId = 1L;
+
+            List<RestaurantReviewProjection> mockList = List.of(
+                    RestaurantReviewProjection.builder().reviewId(1L).build(),
+                    RestaurantReviewProjection.builder().reviewId(2L).build(),
+                    RestaurantReviewProjection.builder().reviewId(3L).build(),
+                    RestaurantReviewProjection.builder().reviewId(4L).build(),
+                    RestaurantReviewProjection.builder().reviewId(5L).build(),
+                    RestaurantReviewProjection.builder().reviewId(6L).build(),
+                    RestaurantReviewProjection.builder().reviewId(7L).build(),
+                    RestaurantReviewProjection.builder().reviewId(8L).build(),
+                    RestaurantReviewProjection.builder().reviewId(9L).build(),
+                    RestaurantReviewProjection.builder().reviewId(10L).build()
+            );
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Mockito.when(imageSeparator.separateConcatenatedImages(null))
+                    .thenReturn(new ArrayList<>());
+
+            Mockito.when(restaurantReviewProjectionRepository.findRestaurantReviewProjectionByRestaurantId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(Pageable.class)
+            )).thenReturn(mockList);
+
+            // When
+            List<ListForRestaurantDTO> actual =
+                    restaurantReviewService.getAllListForRestaurant(restaurantId, pageable);
+
+            // Then
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(10, actual.size())
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("특정 메뉴에 대한 레스토랑 리뷰 리스트 서비스 단위 테스트")
     class listForMenu {
 


### PR DESCRIPTION
음식점 식별자를 전달받아 해당 음식점의 리뷰 리스트를 최신순으로 응답한다.
- #103 
- `GET` /api/reviews/restaurants/{restaurantId}?page
- 페이징 (default size:10, page:0)

### 프로세스
- [x] 요청 URL에서 restaurantId를 추출한다.
- [x] restaurantId를 통해 restaurant, member, review, restaurantReview 테이블을 조회한다.
- [x] 병합된 이미지 url을 리스트로 파싱한 뒤 리뷰 데이터를 응답한다.

### 쿼리
``` SQL
SELECT
    r.id AS review_id,
    r.created_at AS review_created_at,
    r.description AS review_description,
    r.member_id AS member_id,
    rr.restaurant_id AS restaurant_id,
    rr.taste AS review_taste,
    rr.amount AS review_amount,
    rr.service AS review_service,
    rr.speed AS review_speed,
    m.name AS member_name,
    res.name AS restaurant_name,
    GROUP_CONCAT(ri.url) AS urls
FROM review r
INNER JOIN restaurant_review rr ON r.id = rr.id
INNER JOIN member m ON r.member_id = m.id
INNER JOIN restaurant res ON rr.restaurant_id = res.id
LEFT JOIN review_image ri ON ri.review_id = r.id
WHERE rr.restaurant_id = :restaurantId
GROUP BY r.id, rr.id, m.id, res.id
ORDER BY r.created_at
LIMIT 10
OFFSET 0;
```

### 고민
restaurantId는 클라이언트에서 제공하는 값이다.
서버에서는 클라이언트에서 제공하는 값을 신용할 수 없다.

해당 기능은 restaurantId가 유효하지 않다면 쿼리 검색 결과가 존재하지 않기 때문에 
굳이 클라이언트가 제공한 restaurantId의 유효성 검사를 진행할 필요가 없다고 생각한다. 

resolved: #103 