### PR TITLE
룰렛에 사용되는 카테고리, 메뉴 목록 응답 쿼리 수정

### DIFF
--- a/src/main/java/com/livable/server/menu/repository/MenuRepository.java
+++ b/src/main/java/com/livable/server/menu/repository/MenuRepository.java
@@ -11,19 +11,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
-    @Query("SELECT distinct new com.livable.server.menu.dto.RouletteMenuProjection(menu.id, menu.name, mc.name) " +
-            "FROM Member m " +
-            "JOIN Company c " +
-            "ON c.id = m.company.id " +
-            "JOIN BuildingRestaurantMap brm " +
-            "ON brm.building.id = c.building.id " +
-            "JOIN RestaurantMenuMap rmm " +
-            "ON brm.restaurant.id = rmm.restaurant.id " +
-            "JOIN Menu menu " +
-            "ON rmm.menu.id = menu.id " +
-            "JOIN MenuCategory mc " +
-            "ON menu.menuCategory.id = mc.id " +
-            "WHERE m.id = :memberId"
+    @Query("SELECT distinct new com.livable.server.menu.dto.RouletteMenuProjection(m.id, m.name, mc.name) " +
+        "FROM Menu m " +
+        "JOIN MenuCategory mc " +
+        "ON m.menuCategory.id = mc.id"
     )
     List<RouletteMenuProjection> findRouletteMenus(@Param("memberId") Long memberId);
 


### PR DESCRIPTION
- #110 

기존 : 토큰의 memberId로 JOIN, 빌딩 근처에 위치하는 식당들의 메뉴만 반환

변경 : 빌딩 정보와 관련없이 등록된 모든 메뉴 반환