### PR TITLE
목표 달성 포인트 지급 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/Point.java
+++ b/src/main/java/com/livable/server/entity/Point.java
@@ -21,4 +21,8 @@ public class Point extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer balance;
+
+    public void plusPoint(Integer amount) {
+        this.balance += amount;
+    }
 }

--- a/src/main/java/com/livable/server/entity/PointCode.java
+++ b/src/main/java/com/livable/server/entity/PointCode.java
@@ -3,6 +3,8 @@ package com.livable.server.entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
 public enum PointCode {
@@ -13,7 +15,12 @@ public enum PointCode {
     PA03("오점완 7일차 달성 보상"),
     PA04("오점완 14일차 달성 보상"),
     PA05("오점완 21일차 달성 보상"),
+    PA06("오점완 28일차 달성 보상"),
     PM00("제휴 카페 메뉴 할인에 대한 포인트 사용");
 
     private final String description;
+
+    public static List<PointCode> getReviewPointCodes() {
+        return List.of(PA00, PA01, PA02);
+    }
 }

--- a/src/main/java/com/livable/server/point/controller/PointController.java
+++ b/src/main/java/com/livable/server/point/controller/PointController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -25,5 +26,15 @@ public class PointController {
 
         PointResponse.ReviewCountDTO myReviewCount = pointService.getMyReviewCount(memberId, currentDate);
         return ApiResponse.success(myReviewCount, HttpStatus.OK);
+    }
+
+    @PostMapping("/api/points/logs/members")
+    public ResponseEntity<ApiResponse.Success<Object>> getAchievementPoint() {
+
+        Long memberId = 1L; // TODO: 토큰에서 값을 추출할 것
+        LocalDateTime requestDateTime = LocalDateTime.now();
+
+        pointService.getAchievementPoint(memberId, requestDateTime);
+        return ApiResponse.success(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/livable/server/point/domain/DateFactory.java
+++ b/src/main/java/com/livable/server/point/domain/DateFactory.java
@@ -2,6 +2,7 @@ package com.livable.server.point.domain;
 
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 
@@ -10,6 +11,7 @@ public class DateFactory {
 
     /**
      * 기준이 되는 날짜 정보를 받아 해당 month의 시작과 끝 범위의 데이터를 반환한다.
+     *
      * @param localDateTime
      * @return 한달 범위의 시작과 끝 날짜 데이터
      */
@@ -19,5 +21,11 @@ public class DateFactory {
         LocalDateTime endDate = localDateTime.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth());
 
         return new DateRange(startDate, endDate);
+    }
+
+    public LocalDate getPureDate(LocalDateTime localDateTime) {
+        return LocalDate.of(localDateTime.getYear(),
+                localDateTime.getMonth(),
+                localDateTime.getDayOfMonth());
     }
 }

--- a/src/main/java/com/livable/server/point/domain/PointAchievement.java
+++ b/src/main/java/com/livable/server/point/domain/PointAchievement.java
@@ -1,0 +1,51 @@
+package com.livable.server.point.domain;
+
+import com.livable.server.entity.PointCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.InputMismatchException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public enum PointAchievement {
+
+    DAY07(7, 100, PointCode.PA03),
+    DAY14(14, 100, PointCode.PA04),
+    DAY21(21, 100, PointCode.PA05),
+    DAY28(28, 100, PointCode.PA06);
+
+    private final Integer dateCount;
+    private final Integer amount;
+    private final PointCode pointCode;
+
+    public static final List<Integer> DAY_COUNTS;
+    public static final List<PointCode> POINT_CODES;
+
+    static {
+        DAY_COUNTS = Arrays.stream(PointAchievement.values())
+                .map(PointAchievement::getDateCount)
+                .collect(Collectors.toList());
+
+        POINT_CODES = Arrays.stream(PointAchievement.values())
+                .map(PointAchievement::getPointCode)
+                .collect(Collectors.toList());
+    }
+
+    public static PointAchievement valueOf(Integer count) throws InputMismatchException, IllegalArgumentException {
+        if (!DAY_COUNTS.contains(count)) {
+            throw new InputMismatchException();
+        }
+
+        for (PointAchievement pointAchievement : PointAchievement.values()) {
+            Integer dateCount = pointAchievement.getDateCount();
+            if (dateCount.equals(count)) {
+                return pointAchievement;
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/src/main/java/com/livable/server/point/domain/PointErrorCode.java
+++ b/src/main/java/com/livable/server/point/domain/PointErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum PointErrorCode implements ErrorCode {
 
-    POINT_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 포인트 정보입니다.");
+    POINT_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 포인트 정보입니다."),
+    ACHIEVEMENT_POINT_PAID_FAILED(HttpStatus.BAD_REQUEST, "목표달성 포인트는 당일에만 지급받을 수 있습니다."),
+    ACHIEVEMENT_POINT_PAID_ALREADY(HttpStatus.BAD_REQUEST, "금일 목표달성 포인트를 이미 지급 받았습니다."),
+    ACHIEVEMENT_POINT_NOT_MATCHED(HttpStatus.BAD_REQUEST, "목표달성 포인트를 지급 받을 수 있는 리뷰 개수가 부족합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/livable/server/point/dto/PointProjection.java
+++ b/src/main/java/com/livable/server/point/dto/PointProjection.java
@@ -1,0 +1,26 @@
+package com.livable.server.point.dto;
+
+import com.livable.server.entity.Review;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PointProjection {
+
+    @Getter
+    @AllArgsConstructor
+    public static class CountAndDateDTO {
+
+        private Long count;
+        private LocalDateTime mostRecentCreatedDate;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReviewAndDateDTO {
+
+        private Review review;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/livable/server/point/dto/PointResponse.java
+++ b/src/main/java/com/livable/server/point/dto/PointResponse.java
@@ -2,6 +2,8 @@ package com.livable.server.point.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PointResponse {
 
@@ -10,5 +12,13 @@ public class PointResponse {
     public static class ReviewCountDTO {
 
         private Long count;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CountAndDateDTO {
+
+        private Long count;
+        private LocalDateTime mostRecentCreatedDate;
     }
 }

--- a/src/main/java/com/livable/server/point/repository/PointLogRepository.java
+++ b/src/main/java/com/livable/server/point/repository/PointLogRepository.java
@@ -1,0 +1,15 @@
+package com.livable.server.point.repository;
+
+import com.livable.server.entity.PointLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface PointLogRepository extends JpaRepository<PointLog, Long> {
+
+    @Query(value = "SELECT * FROM point_log WHERE DATE(created_at) = :date", nativeQuery = true)
+    List<PointLog> findLogsByDate(@Param("date") LocalDate date);
+}

--- a/src/main/java/com/livable/server/point/repository/PointRepository.java
+++ b/src/main/java/com/livable/server/point/repository/PointRepository.java
@@ -2,6 +2,7 @@ package com.livable.server.point.repository;
 
 import com.livable.server.entity.Point;
 import com.livable.server.entity.PointCode;
+import com.livable.server.point.dto.PointProjection;
 import com.livable.server.point.dto.PointResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +14,7 @@ import java.util.Optional;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
-    Optional<Point> findByMember_Id(Long memberId);
+    Optional<Point> findByMemberId(Long memberId);
 
     @Query("SELECT new com.livable.server.point.dto.PointResponse$ReviewCountDTO(COUNT(pl.id)) " +
             "FROM PointLog pl " +
@@ -21,6 +22,29 @@ public interface PointRepository extends JpaRepository<Point, Long> {
             "AND pl.createdAt BETWEEN :startDate AND :endDate " +
             "AND pl.code IN (:codes)")
     PointResponse.ReviewCountDTO findPointCountById(
+            @Param("pointId") Long pointId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("codes") List<PointCode> codes);
+
+    @Query("SELECT new com.livable.server.point.dto.PointProjection$CountAndDateDTO(COUNT(pl.id), MAX(pl.createdAt)) " +
+            "FROM PointLog pl " +
+            "WHERE pl.point.id = :pointId " +
+            "AND pl.createdAt BETWEEN :startDate AND :endDate " +
+            "AND pl.code IN (:codes)")
+    PointProjection.CountAndDateDTO findCountAndDateById(
+            @Param("pointId") Long pointId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("codes") List<PointCode> codes);
+
+    @Query("SELECT new com.livable.server.point.dto.PointProjection$ReviewAndDateDTO(pl.review, pl.createdAt) " +
+            "FROM PointLog pl " +
+            "WHERE pl.point.id = :pointId " +
+            "AND pl.createdAt BETWEEN :startDate AND :endDate " +
+            "AND pl.code IN (:codes)" +
+            "ORDER BY pl.createdAt DESC")
+    List<PointProjection.ReviewAndDateDTO> findReviewAndDateById(
             @Param("pointId") Long pointId,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate,

--- a/src/main/java/com/livable/server/point/service/PointService.java
+++ b/src/main/java/com/livable/server/point/service/PointService.java
@@ -3,17 +3,25 @@ package com.livable.server.point.service;
 import com.livable.server.core.exception.GlobalRuntimeException;
 import com.livable.server.entity.Point;
 import com.livable.server.entity.PointCode;
-import com.livable.server.member.domain.MemberErrorCode;
+import com.livable.server.entity.PointLog;
+import com.livable.server.entity.Review;
 import com.livable.server.point.domain.DateFactory;
 import com.livable.server.point.domain.DateRange;
+import com.livable.server.point.domain.PointAchievement;
 import com.livable.server.point.domain.PointErrorCode;
+import com.livable.server.point.dto.PointProjection;
 import com.livable.server.point.dto.PointResponse;
+import com.livable.server.point.repository.PointLogRepository;
 import com.livable.server.point.repository.PointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.InputMismatchException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -21,12 +29,13 @@ import java.util.List;
 public class PointService {
 
     private final PointRepository pointRepository;
+    private final PointLogRepository pointLogRepository;
     private final DateFactory dateFactory;
 
     @Transactional(readOnly = true)
     public PointResponse.ReviewCountDTO getMyReviewCount(Long memberId, LocalDateTime currentDate) {
 
-        Point point = pointRepository.findByMember_Id(memberId).orElseThrow(() ->
+        Point point = pointRepository.findByMemberId(memberId).orElseThrow(() ->
                 new GlobalRuntimeException(PointErrorCode.POINT_NOT_EXIST));
 
         DateRange dateRange = dateFactory.getMonthRangeOf(currentDate);
@@ -35,7 +44,73 @@ public class PointService {
                 point.getId(),
                 dateRange.getStartDate(),
                 dateRange.getEndDate(),
-                List.of(PointCode.PA00, PointCode.PA01, PointCode.PA02)
+                PointCode.getReviewPointCodes()
         );
+    }
+
+    @Transactional
+    public void getAchievementPoint(Long memberId, LocalDateTime requestDateTime) {
+
+        System.out.println("requestDateTime:" + requestDateTime);
+
+        // 회원 정보가 유효한지 검증
+        Point point = pointRepository.findByMemberId(memberId).orElseThrow(() ->
+                new GlobalRuntimeException(PointErrorCode.POINT_NOT_EXIST));
+
+        // 금일 이미 목표 달성 포인트를 지급받았는지 확인
+        LocalDate requestDate = dateFactory.getPureDate(requestDateTime);
+        List<PointLog> logsByDate = pointLogRepository.findLogsByDate(requestDate);
+        System.out.println(logsByDate.get(0).getCode());
+        logsByDate.forEach(pointLog -> {
+            if (PointAchievement.POINT_CODES.contains(pointLog.getCode())) {
+                throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_PAID_ALREADY);
+            }
+        });
+
+        // 현재의 년-월 범위에 해당하는 리뷰를 조회
+        DateRange requestedDateOfMonthRange = dateFactory.getMonthRangeOf(requestDateTime);
+        List<PointProjection.ReviewAndDateDTO> reviewAndDates = pointRepository.findReviewAndDateById(
+                point.getId(),
+                requestedDateOfMonthRange.getStartDate(),
+                requestedDateOfMonthRange.getEndDate(),
+                PointCode.getReviewPointCodes()
+        );
+
+        PointProjection.ReviewAndDateDTO lastReview = reviewAndDates.get(0);
+
+        Review review = lastReview.getReview();
+        LocalDateTime lastCreatedDate = lastReview.getCreatedAt();
+        Integer count = reviewAndDates.size();
+        PointAchievement pointAchievement;
+
+        // 리뷰 개수가 목표 달성으로 치환되는지 확인
+        try {
+            pointAchievement = PointAchievement.valueOf(count);
+        } catch (InputMismatchException exception) {
+            throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_NOT_MATCHED);
+        }
+
+        // 목표 포인트 지급 요청 날짜가 지급받을 수 있는 날짜인지 확인
+        if (lastCreatedDate.getDayOfMonth() != requestDateTime.getDayOfMonth()) {
+            throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_PAID_FAILED);
+        }
+
+        // 포인트 지급
+        this.paidPoints(point, pointAchievement, review);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
+    public void paidPoints(Point point, PointAchievement pointAchievement, Review review) {
+
+        Integer amount = pointAchievement.getAmount();
+
+        point.plusPoint(amount);
+        PointLog pointLog = PointLog.builder()
+                .point(point)
+                .review(review)
+                .code(pointAchievement.getPointCode())
+                .amount(pointAchievement.getAmount())
+                .build();
+        pointLogRepository.save(pointLog);
     }
 }


### PR DESCRIPTION
포인트를 받을 수 있는 리뷰(이미지가 첨부된 사진)를 `7`, `14`, `21`, `28`번째 작성했을 시, 목표 달성 포인트를 얻을 수 있다.
목표 달성 포인트는 목표 달성 페이지에 활성화된 버튼을 클릭하는 경우 지급받을 수 있다.

- #106 
- 목표 달성 포인트는 목표를 달성한 당일이 아닌 경우 지급받지 못한다.
- 위의 시간 판단은 서버에서 진행된다.
- `POST` /api/points/logs/members
요청 시간을 클라이언트의 Request의 header애서 추출하려고 했으나 해당 데이터는 클라이언트가 임의로 변경할 가능성이 있다.
따라서 보안적인 문제가 발생할 수 있기 때문에 요청 시간은 서버가 요청을 받는 시점에 판단한다.

요청이 빈번하게 발생하지 않는 기능이기 때문에 성능보다는 보안이 중요하다고 생각된다.
여러번의 IO가 발생하더라도 모든 검증을 진행하도록 한다.

유효성 체크
- 토큰으로 추출된 유저 식별자가 유효한가
- 금일 이미 목표 달성 포인트를 받았는가
- 포인트를 받을 수 있는 목표를 달성했는가 
- 포인트를 받을  수 있는 당일에 요청을 했는가

### 쿼리
```SQL
select 
    COUNT(*) AS count,
    MAX(created_at) AS mostRecentCreatedDate
from point_log
where point_log.point_id = 1
AND created_at BETWEEN :startDate AND :endDate
AND code IN (:codes);
```

### 프로세스
- [x] 요청을 받은 시점에 서버에서 현재 시간(requestTime)을 측정한다.
- [x] 토큰에서 memberId를 추출한다.
- [x] member_id를 통해 Point 테이블의 id를 조회한다.
- [x] point.id를 통해 Point_log테이블을 조회한다.
  - [x] 포인트 획득 일자가 데이터를 요청한 날짜의 년-월 데이터가 동일해야 한다.
  - [x] 포인트 획득 코드가 리뷰작성과 관련된 코드여야 한다. (PA00, PA01, PA02)
- [x] 조회결과의 count가 7, 14, 21, 28인지 검증한다. (count를 통해 Enum을 가져올 방법을 생각해보자)
- [x] 조회결과의 마지막 작성 리뷰의 일자와 현재 시간의 일자가 동일한지 판단한다.
  - [x] 동일하다면 포인트를 지급한 뒤 로그를 저장한다.
  - [x] 동일하지 않다면 오류 메시지를 반환한다.
- [x] 포인트를 지급하는 작업과 로그를 저장하는 작업은 하나의 트랜잭션이다.

### 고민
클라이언트가 7일차 리뷰를 작성하고 목표 달성 포인트 페이지에 진입했다면,
목표달성 포인트 지급 버튼을 누를 확률은 100%에 근접하다고 생각한다.

현재 로직 상 목표 달성 포인트 지급에서는
목표 달성 포인트 페이지에 진입했을 때 동작하는 로직을 동일하게 한번 더 실행하게 된다.
(같은 데이터를 같은 형식으로 불러온다.)

만약에 목표 달성 포인트 페이지에 필요한 데이터를 가져왔을 때,
목표 달성 포인트를 받을 수 있다고 판단 되는 데이터인 경우라면
해당 데이터를 2차 캐시에 저장해두고 재사용하는 방식을 사용한다면 성능이 향상될까?

resolved: #106 