### PR TITLE
Reservation 도메인에 대한 리팩터링 완료

### DIFF
--- a/src/main/java/com/livable/server/invitation/repository/InvitationReservationMapRepository.java
+++ b/src/main/java/com/livable/server/invitation/repository/InvitationReservationMapRepository.java
@@ -5,9 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface InvitationReservationMapRepository extends JpaRepository<InvitationReservationMap, Long> {
 
     @Modifying
     @Query("delete from InvitationReservationMap irm where irm.invitation.id = :invitationId")
     void deleteAllByInvitationId(Long invitationId);
+
+    @Query("select ir.reservation.id from InvitationReservationMap ir")
+    List<Long> findAllReservationId();
 }

--- a/src/main/java/com/livable/server/reservation/repository/ReservationQueryRepository.java
+++ b/src/main/java/com/livable/server/reservation/repository/ReservationQueryRepository.java
@@ -16,4 +16,8 @@ public interface ReservationQueryRepository {
     List<AvailableReservationTimeProjection> findNotUsedReservationTime(
             Long companyId, Long commonPlaceId, LocalDate date
     );
+
+    List<AvailableReservationTimeProjection> findNotUsedReservationTimeByUsedReservationIds(
+            Long companyId, Long commonPlaceId, LocalDate date, List<Long> reservationIds
+    );
 }

--- a/src/main/java/com/livable/server/reservation/repository/ReservationQueryRepositoryImpl.java
+++ b/src/main/java/com/livable/server/reservation/repository/ReservationQueryRepositoryImpl.java
@@ -96,4 +96,25 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
                 )
                 .fetch();
     }
+
+    @Override
+    public List<AvailableReservationTimeProjection> findNotUsedReservationTimeByUsedReservationIds(
+            Long companyId, Long commonPlaceId, LocalDate date, List<Long> reservationIds
+    ) {
+        return queryFactory
+                .select(Projections.constructor(AvailableReservationTimeProjection.class,
+                                reservation.date,
+                                reservation.time
+                        )
+                )
+                .from(reservation)
+                .where(reservation.id.notIn(
+                                reservationIds
+                        ),
+                        reservation.company.id.eq(companyId),
+                        reservation.date.eq(date),
+                        reservation.commonPlace.id.eq(commonPlaceId)
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/com/livable/server/reservation/service/ReservationService.java
+++ b/src/main/java/com/livable/server/reservation/service/ReservationService.java
@@ -2,6 +2,7 @@ package com.livable.server.reservation.service;
 
 import com.livable.server.core.exception.GlobalRuntimeException;
 import com.livable.server.entity.Member;
+import com.livable.server.invitation.repository.InvitationReservationMapRepository;
 import com.livable.server.member.domain.MemberErrorCode;
 import com.livable.server.member.repository.MemberRepository;
 import com.livable.server.reservation.dto.AvailableReservationTimeProjection;
@@ -12,10 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -23,12 +21,15 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
+    private final InvitationReservationMapRepository invitationReservationMapRepository;
 
     public List<ReservationResponse.AvailableReservationTimePerDateDto> findAvailableReservationTimes(
             Long memberId,
             Long commonPlaceId,
             LocalDate date
     ) {
+
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalRuntimeException(MemberErrorCode.MEMBER_NOT_EXIST));
 
@@ -41,8 +42,11 @@ public class ReservationService {
     private AvailableReservationTimeProjections getAvailableReservationTimeProjections(
             Long companyId, Long commonPlaceId, LocalDate date
     ) {
+        List<Long> usedReservationIds = invitationReservationMapRepository.findAllReservationId();
         List<AvailableReservationTimeProjection> timeProjections =
-                reservationRepository.findNotUsedReservationTime(companyId, commonPlaceId, date);
+                reservationRepository.findNotUsedReservationTimeByUsedReservationIds(
+                        companyId, commonPlaceId, date, usedReservationIds
+                );
 
         return new AvailableReservationTimeProjections(timeProjections);
     }

--- a/src/test/java/com/livable/server/core/util/StringToLocalDateConverterTest.java
+++ b/src/test/java/com/livable/server/core/util/StringToLocalDateConverterTest.java
@@ -1,0 +1,21 @@
+package com.livable.server.core.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class StringToLocalDateConverterTest {
+
+    @DisplayName("StringToLocalDateConverter.convert 성공 테스트")
+    @Test
+    void convertSuccessTest() {
+        StringToLocalDateConverter converter = new StringToLocalDateConverter();
+
+        String query = "2023-04-23";
+
+        assertThat(LocalDate.of(2023, 4, 23)).isEqualTo(converter.convert(query));
+    }
+}


### PR DESCRIPTION
- #135 

### 서브쿼리를 사용하여 한번의 쿼리로 조회할 때
![image](https://github.com/livable-final/server/assets/109710879/e9f74e60-ea37-47f6-9e94-a7d0f8939e5f)

### 서브쿼리를 따로 분리하여 두번의 쿼리로 조회할 때
![image](https://github.com/livable-final/server/assets/109710879/a41c87e4-dd78-4343-a8ec-f998e1eea843)

I/O가 두번 일어나지만 총 TPS는 늘어났기에 두번의 쿼리로 분리하는 리팩토링 적용