### PR TITLE
포인트 로그 도메인 개선 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/PointLog.java
+++ b/src/main/java/com/livable/server/entity/PointLog.java
@@ -32,9 +32,24 @@ public class PointLog extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer amount;
 
+    @Column(nullable = false)
+    private LocalDateTime paidAt;
+
+    @PrePersist
+    private void prePersist() {
+        paidAt = LocalDateTime.now();
+    }
+
+    public boolean isPaid(LocalDate date) {
+        LocalDateTime paidDateTime = this.getPaidAt();
+        LocalDate paidDate = LocalDate.of(paidDateTime.getYear(), paidDateTime.getMonth(), paidDateTime.getDayOfMonth());
+
+        return paidDate.equals(date);
+    }
+
     public boolean isCreated(LocalDate date) {
-        LocalDateTime createdAt = this.getCreatedAt();
-        LocalDate createdDate = LocalDate.of(createdAt.getYear(), createdAt.getMonth(), createdAt.getDayOfMonth());
+        LocalDateTime createdDateTime = this.getCreatedAt();
+        LocalDate createdDate = LocalDate.of(createdDateTime.getYear(), createdDateTime.getMonth(), createdDateTime.getDayOfMonth());
 
         return createdDate.equals(date);
     }


### PR DESCRIPTION
현재 `created_at` 이라는 모든 엔티티의 공통 컬럼을 사용하여 로직이 실행된다.
하지만 `created_at`, `updated_at` 은 해당 로우의 로그를 위한 데이터이지 비즈니스 로직을 위한 컬럼이 아니다.
따라서 `paid_at` 이라는 포인트 지급 날짜 컬럼을 추가하여 로직에서 사용할 수 있도록 한다.
- #165 

resolved: #165 
