### PR TITLE
포인트 로그 개선에 따른 목표 달성 포인트 지급 서비스 수정 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/PointLog.java
+++ b/src/main/java/com/livable/server/entity/PointLog.java
@@ -46,11 +46,4 @@ public class PointLog extends BaseTimeEntity {
 
         return paidDate.equals(date);
     }
-
-    public boolean isCreated(LocalDate date) {
-        LocalDateTime createdDateTime = this.getCreatedAt();
-        LocalDate createdDate = LocalDate.of(createdDateTime.getYear(), createdDateTime.getMonth(), createdDateTime.getDayOfMonth());
-
-        return createdDate.equals(date);
-    }
 }

--- a/src/main/java/com/livable/server/point/domain/PointErrorCode.java
+++ b/src/main/java/com/livable/server/point/domain/PointErrorCode.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum PointErrorCode implements ErrorCode {
 
     POINT_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 포인트 정보입니다."),
+    POINT_NOT_EXIST_FOR_CURRENT_MONTH(HttpStatus.BAD_REQUEST, "현재 달에 지급된 리뷰 포인트가 존재하지 않습니다."),
     ACHIEVEMENT_POINT_PAID_FAILED(HttpStatus.BAD_REQUEST, "목표달성 포인트는 당일에만 지급받을 수 있습니다."),
     ACHIEVEMENT_POINT_PAID_ALREADY(HttpStatus.BAD_REQUEST, "금일 목표달성 포인트를 이미 지급 받았습니다."),
     ACHIEVEMENT_POINT_NOT_MATCHED(HttpStatus.BAD_REQUEST, "목표달성 포인트를 지급 받을 수 있는 리뷰 개수가 부족합니다.");

--- a/src/main/java/com/livable/server/point/repository/PointLogRepository.java
+++ b/src/main/java/com/livable/server/point/repository/PointLogRepository.java
@@ -13,8 +13,8 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     @Query(value = "SELECT * " +
             "FROM point_log " +
             "WHERE point_id = :pointId " +
-            "AND created_at BETWEEN :startDate AND :endDate " +
-            "ORDER BY created_at DESC", nativeQuery = true)
+            "AND paid_at BETWEEN :startDate AND :endDate " +
+            "ORDER BY paid_at DESC", nativeQuery = true)
     List<PointLog> findDateRangeOfPointLogByPointId(
             @Param("pointId") Long pointId,
             @Param("startDate") LocalDateTime startDate,

--- a/src/main/java/com/livable/server/point/service/PointService.java
+++ b/src/main/java/com/livable/server/point/service/PointService.java
@@ -66,7 +66,7 @@ public class PointService {
         PointAchievement pointAchievement = this.getPointAchievementFrom(pointLogs);
 
         // 목표 포인트 지급 요청 날짜가 포인트를 지급받을 수 있는 날짜인지 확인
-        if (!recentPointLog.isCreated(requestDate)) {
+        if (!recentPointLog.isPaid(requestDate)) {
             throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_PAID_FAILED);
         }
 
@@ -100,7 +100,7 @@ public class PointService {
      */
     private PointLog getRecentPointLogFrom(List<PointLog> pointLogs) throws GlobalRuntimeException {
         return pointLogs.stream().findFirst()
-                .orElseThrow(() -> new GlobalRuntimeException(PointErrorCode.POINT_NOT_EXIST));
+                .orElseThrow(() -> new GlobalRuntimeException(PointErrorCode.POINT_NOT_EXIST_FOR_CURRENT_MONTH));
     }
 
     /**
@@ -111,7 +111,7 @@ public class PointService {
      */
     private void validationAchievementPointAlreadyPaid(List<PointLog> pointLogs, LocalDate requestDate) {
         pointLogs.stream()
-                .filter(pointLog -> pointLog.isCreated(requestDate))
+                .filter(pointLog -> pointLog.isPaid(requestDate))
                 .forEach(pointLog -> {
                     if (PointAchievement.POINT_CODES.contains(pointLog.getCode())) {
                         throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_PAID_ALREADY);
@@ -139,7 +139,6 @@ public class PointService {
             throw new GlobalRuntimeException(PointErrorCode.ACHIEVEMENT_POINT_NOT_MATCHED);
         }
     }
-
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
     public void paidPoints(Point point, PointAchievement pointAchievement, Review review) {

--- a/src/test/java/com/livable/server/point/service/PointServiceTest.java
+++ b/src/test/java/com/livable/server/point/service/PointServiceTest.java
@@ -7,12 +7,11 @@ import com.livable.server.entity.PointLog;
 import com.livable.server.entity.Review;
 import com.livable.server.point.domain.DateFactory;
 import com.livable.server.point.domain.DateRange;
+import com.livable.server.point.domain.PointErrorCode;
 import com.livable.server.point.dto.PointResponse;
+import com.livable.server.point.repository.PointLogRepository;
 import com.livable.server.point.repository.PointRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
@@ -20,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +29,9 @@ class PointServiceTest {
 
     @Mock
     private PointRepository pointRepository;
+
+    @Mock
+    private PointLogRepository pointLogRepository;
 
     @Mock
     private DateFactory dateFactory;
@@ -94,45 +97,177 @@ class PointServiceTest {
     @DisplayName("목표 달성 포인트 지급 서비스 단위 테스트")
     class GetAchievementPoint {
 
-        @DisplayName("성공 - 일곱개의 리뷰 포인트 로그가 주어지는 경우, 목표 포인트를 지급한다.")
+        @BeforeEach
+        void setUp() {
+            LocalDateTime startDate = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+            LocalDateTime endDte = LocalDateTime.of(2023, 2, 1, 0, 0, 0);
+            DateRange dateRange = new DateRange(startDate, endDte);
+
+            Mockito.when(dateFactory.getMonthRangeOf(ArgumentMatchers.any(LocalDateTime.class)))
+                    .thenReturn(dateRange);
+
+            LocalDate pureDate = LocalDate.of(2023, 1, 1);
+            Mockito.when(dateFactory.getPureDate(ArgumentMatchers.any(LocalDateTime.class)))
+                    .thenReturn(pureDate);
+        }
+
+        @DisplayName("성공 - 7개의 리뷰 포인트 로그가 주어지는 경우, 목표 포인트를 지급한다.")
         @Test
         void success_Test_GivenSevenReviewPointLog_ThenPaidAchievementPoint() {
             // Given
-            Point point = Point.builder().balance(10).build();
+            Long memberId = 1L;
+            LocalDateTime requestTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+            LocalDateTime paidTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+
+            Point point = Point.builder().id(1L).balance(10).build();
             Review review = Review.builder().id(1L).build();
             List<PointLog> MockList = List.of(
-                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).build(),
-                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(4L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(5L).point(point).review(review).code(PointCode.PA02).build(),
-                    PointLog.builder().id(6L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(7L).point(point).review(review).code(PointCode.PA01).build()
+                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(4L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(5L).point(point).review(review).code(PointCode.PA02).paidAt(paidTime).build(),
+                    PointLog.builder().id(6L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(7L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build()
             );
-            // When
 
+            Mockito.when(pointRepository.findByMemberId(ArgumentMatchers.anyLong()))
+                            .thenReturn(Optional.of(point));
+
+            Mockito.when(pointLogRepository.findDateRangeOfPointLogByPointId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(LocalDateTime.class),
+                    ArgumentMatchers.any(LocalDateTime.class)
+            )).thenReturn(MockList);
+
+            // When
             // Then
+            pointService.getAchievementPoint(memberId, requestTime);
         }
 
-        @DisplayName("실패 - 목표는 달성 했지만 포인트 신청 날짜가 목표 달성 당일이 아닌 경우, 예외를 발생한다.")
+        @DisplayName("성공 - 14개의 리뷰 포인트 로그가 주어지는 경우, 목표 포인트를 지급한다.")
         @Test
-        void failure_Test_GivenRequestNotAchievingDate_ThenThrowError() {
+        void success_Test_GivenFourTeenReviewPointLog_ThenPaidAchievementPoint() {
             // Given
-            Point point = Point.builder().balance(10).build();
+            Long memberId = 1L;
+            LocalDateTime requestTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+            LocalDateTime paidTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+
+            Point point = Point.builder().id(1L).balance(10).build();
             Review review = Review.builder().id(1L).build();
             List<PointLog> MockList = List.of(
-                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).build(),
-                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(4L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(5L).point(point).review(review).code(PointCode.PA02).build(),
-                    PointLog.builder().id(6L).point(point).review(review).code(PointCode.PA00).build(),
-                    PointLog.builder().id(7L).point(point).review(review).code(PointCode.PA01).build()
+                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(4L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(5L).point(point).review(review).code(PointCode.PA02).paidAt(paidTime).build(),
+                    PointLog.builder().id(6L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(7L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(8L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(9L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(10L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(11L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(12L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(13L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(14L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build()
             );
 
-            // When
+            Mockito.when(pointRepository.findByMemberId(ArgumentMatchers.anyLong()))
+                    .thenReturn(Optional.of(point));
 
+            Mockito.when(pointLogRepository.findDateRangeOfPointLogByPointId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(LocalDateTime.class),
+                    ArgumentMatchers.any(LocalDateTime.class)
+            )).thenReturn(MockList);
+
+            // When
             // Then
+            pointService.getAchievementPoint(memberId, requestTime);
+        }
+
+        @DisplayName("실패 - 3개의 리뷰 포인트 로그가 주어지는 경우, 목표를 달성하지 않았다는 메시지 예외를 발생한다.")
+        @Test
+        void failure_Test_GivenThreeReviewPointLog_ThenThrowsErrorWithMessage() {
+            // Given
+            Long memberId = 1L;
+            LocalDateTime requestTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+            LocalDateTime paidTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+
+            Point point = Point.builder().id(1L).balance(10).build();
+            Review review = Review.builder().id(1L).build();
+            List<PointLog> MockList = List.of(
+                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build()
+            );
+
+            Mockito.when(pointRepository.findByMemberId(ArgumentMatchers.anyLong()))
+                    .thenReturn(Optional.of(point));
+
+            Mockito.when(pointLogRepository.findDateRangeOfPointLogByPointId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(LocalDateTime.class),
+                    ArgumentMatchers.any(LocalDateTime.class)
+            )).thenReturn(MockList);
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class,
+                    () -> pointService.getAchievementPoint(memberId, requestTime));
+
+            try {
+                pointService.getAchievementPoint(memberId, requestTime);
+            } catch (GlobalRuntimeException exception) {
+                Assertions.assertEquals(
+                        PointErrorCode.ACHIEVEMENT_POINT_NOT_MATCHED.getMessage(), exception.getMessage());
+            }
+        }
+
+        @DisplayName("실패 - 11개의 리뷰 포인트 로그가 주어지는 경우, 목표를 달성하지 않았다는 메시지 예외를 발생한다.")
+        @Test
+        void failure_Test_GivenElevenReviewPointLog_ThenThrowsErrorWithMessage() {
+            // Given
+            Long memberId = 1L;
+            LocalDateTime requestTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+            LocalDateTime paidTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+
+            Point point = Point.builder().id(1L).balance(10).build();
+            Review review = Review.builder().id(1L).build();
+            List<PointLog> MockList = List.of(
+                    PointLog.builder().id(1L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(2L).point(point).review(review).code(PointCode.PA01).paidAt(paidTime).build(),
+                    PointLog.builder().id(3L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(4L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(5L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(6L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(7L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(8L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(9L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(10L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build(),
+                    PointLog.builder().id(11L).point(point).review(review).code(PointCode.PA00).paidAt(paidTime).build()
+            );
+
+            Mockito.when(pointRepository.findByMemberId(ArgumentMatchers.anyLong()))
+                    .thenReturn(Optional.of(point));
+
+            Mockito.when(pointLogRepository.findDateRangeOfPointLogByPointId(
+                    ArgumentMatchers.anyLong(),
+                    ArgumentMatchers.any(LocalDateTime.class),
+                    ArgumentMatchers.any(LocalDateTime.class)
+            )).thenReturn(MockList);
+
+            // When
+            // Then
+            Assertions.assertThrows(GlobalRuntimeException.class,
+                    () -> pointService.getAchievementPoint(memberId, requestTime));
+
+            try {
+                pointService.getAchievementPoint(memberId, requestTime);
+            } catch (GlobalRuntimeException exception) {
+                Assertions.assertEquals(
+                        PointErrorCode.ACHIEVEMENT_POINT_NOT_MATCHED.getMessage(), exception.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
기존의 created_at 으로 동작하던 로직을 paid_at 컬럼을 사용하여 동작하도록 수정한다.
추가로 테스트코드를 작성하지 못하는 상황이 해결되었기 때문에 테스트 코드까지 작성한다.
- #167 

resolved: #167 