### PR TITLE
리뷰 상세데이터를 포함한 오점완 달력 데이터 응답 기능 구현 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/Review.java
+++ b/src/main/java/com/livable/server/entity/Review.java
@@ -1,5 +1,6 @@
 package com.livable.server.entity;
 
+import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.ReviewResponse;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -20,6 +21,21 @@ import java.time.LocalDateTime;
                         @ColumnResult(name = "type", type = String.class),
                         @ColumnResult(name = "reviewImageUrl", type = String.class),
                         @ColumnResult(name = "reviewDate", type = LocalDate.class)
+                }
+        )
+)
+@SqlResultSetMapping(
+        name = "AllReviewDetailListMapping",
+        classes = @ConstructorResult(
+                targetClass = Projection.AllReviewDetailDTO.class,
+                columns = {
+                        @ColumnResult(name = "reviewTitle", type = String.class),
+                        @ColumnResult(name = "reviewTaste", type = String.class),
+                        @ColumnResult(name = "reviewDescription", type = String.class),
+                        @ColumnResult(name = "reviewCreatedAt", type = String.class),
+                        @ColumnResult(name = "location", type = String.class),
+                        @ColumnResult(name = "images", type = String.class),
+                        @ColumnResult(name = "reviewType", type = String.class)
                 }
         )
 )

--- a/src/main/java/com/livable/server/review/controller/ReviewController.java
+++ b/src/main/java/com/livable/server/review/controller/ReviewController.java
@@ -84,4 +84,17 @@ public class ReviewController {
 
         return ApiResponse.success(result, HttpStatus.OK);
     }
+
+    @GetMapping("/detail/members")
+    public ResponseEntity<Success<List<ReviewResponse.DetailListDTO>>> findAllReviewDetail(
+            @RequestParam Integer year,
+            @RequestParam Integer month,
+            @LoginActor Actor actor) {
+
+        JwtTokenProvider.checkMemberToken(actor);
+        Long memberId = actor.getId();
+
+        List<ReviewResponse.DetailListDTO> result = reviewService.findAllReviewDetailList(memberId, year, month);
+        return ApiResponse.success(result, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/livable/server/review/dto/Projection.java
+++ b/src/main/java/com/livable/server/review/dto/Projection.java
@@ -4,6 +4,7 @@ import com.livable.server.entity.Evaluation;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class Projection {
 
@@ -47,5 +48,30 @@ public class Projection {
         private Evaluation reviewSpeed;
 
         private String images;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AllReviewDetailDTO {
+
+        private String reviewTitle;
+        private Evaluation reviewTaste;
+        private String reviewDescription;
+        private String reviewCreatedAt;
+        private String location;
+        private String images;
+        private String reviewType;
+
+        public AllReviewDetailDTO(String reviewTitle, String reviewTaste, String reviewDescription, String reviewCreatedAt, String location, String images, String reviewType) {
+
+            this.reviewTitle = reviewTitle;
+            this.reviewTaste = Objects.isNull(reviewTaste) ? null : Evaluation.valueOf(reviewTaste);
+            this.reviewDescription = reviewDescription;
+            this.reviewCreatedAt = reviewCreatedAt;
+            this.location = location;
+            this.images = images;
+            this.reviewType = reviewType;
+        }
     }
 }

--- a/src/main/java/com/livable/server/review/dto/ReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/ReviewResponse.java
@@ -1,8 +1,12 @@
 package com.livable.server.review.dto;
 
+import com.livable.server.core.util.ImageSeparator;
+import com.livable.server.entity.Evaluation;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class ReviewResponse {
 
@@ -18,6 +22,31 @@ public class ReviewResponse {
             this.type = type;
             this.reviewImageUrl = reviewImageUrl;
             this.reviewDate = reviewDate;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DetailListDTO {
+
+        private String reviewTitle;
+        private Evaluation reviewTaste;
+        private String reviewDescription;
+        private String reviewCreatedAt;
+        private String location;
+        private List<String> images;
+        private String reviewType;
+
+        public static DetailListDTO valueOf(Projection.AllReviewDetailDTO detailDTO, ImageSeparator imageSeparator) {
+            return DetailListDTO.builder()
+                    .reviewTitle(detailDTO.getReviewTitle())
+                    .reviewTaste(detailDTO.getReviewTaste())
+                    .reviewDescription(detailDTO.getReviewDescription())
+                    .reviewCreatedAt(detailDTO.getReviewCreatedAt())
+                    .location(detailDTO.getLocation())
+                    .images(imageSeparator.separateConcatenatedImages(detailDTO.getImages()))
+                    .reviewType(detailDTO.getReviewType())
+                    .build();
         }
     }
 }

--- a/src/main/java/com/livable/server/review/repository/ReviewProjectionRepository.java
+++ b/src/main/java/com/livable/server/review/repository/ReviewProjectionRepository.java
@@ -1,16 +1,21 @@
 package com.livable.server.review.repository;
 
+import com.livable.server.core.util.ImageSeparator;
+import com.livable.server.review.dto.Projection;
 import com.livable.server.review.dto.ReviewResponse;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public class ReviewProjectionRepository {
+
     private static final String FIND_ALL_REVIEWS_BY_YEAR_AND_MONTH_QUERY;
+    private static final String FIND_ALL_REVIEW_DETAIL_BETWEEN_DATE_QUERY;
 
     static {
         FIND_ALL_REVIEWS_BY_YEAR_AND_MONTH_QUERY = "select  " +
@@ -53,6 +58,55 @@ public class ReviewProjectionRepository {
                 "group by r.id) as result " +
                 "where year(result.created_at) = :year and month(result.created_at) = :month " +
                 "order by result.created_at";
+
+        FIND_ALL_REVIEW_DETAIL_BETWEEN_DATE_QUERY = "SELECT * " +
+                "FROM (" +
+                "SELECT " +
+                "review.selected_dishes as reviewTitle, " +
+                "restaurant_review.taste as reviewTaste, " +
+                "review.description as reviewDescription, " +
+                "date_format(review.created_at, \"%Y-%m-%d\") as reviewCreatedAt, " +
+                "restaurant.name as location, " +
+                "GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images, " +
+                "'restaurant' AS reviewType " +
+                "FROM review " +
+                "LEFT JOIN review_image ON review_image.review_id = review.id " +
+                "INNER JOIN restaurant_review on restaurant_review.id = review.id " +
+                "INNER JOIN restaurant on restaurant.id = restaurant_review.restaurant_id " +
+                "WHERE review.member_id = :memberId " +
+                "GROUP BY review.id, review.member_id " +
+                "UNION " +
+                "SELECT " +
+                "review.selected_dishes as reviewTitle, " +
+                "cafeteria_review.taste as reviewTaste, " +
+                "review.description as reviewDescription, " +
+                "date_format(review.created_at, \"%Y-%m-%d\") as reviewCreatedAt, " +
+                "building.name as location, " +
+                "GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images, " +
+                "'cafeteria' AS reviewType " +
+                "FROM review " +
+                "LEFT JOIN review_image ON review_image.review_id = review.id " +
+                "INNER JOIN cafeteria_review on cafeteria_review.id = review.id " +
+                "INNER JOIN building on building.id = cafeteria_review.building_id " +
+                "WHERE review.member_id = :memberId " +
+                "GROUP BY review.id, review.member_id " +
+                "UNION " +
+                "SELECT " +
+                "review.selected_dishes as reviewTitle, " +
+                "NULL as reviewTaste, " +
+                "review.description as reviewDescription, " +
+                "date_format(review.created_at, \"%Y-%m-%d\") as reviewCreatedAt, " +
+                "NULL as location, " +
+                "GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images, " +
+                "'lunchBox' AS reviewType " +
+                "FROM review " +
+                "LEFT JOIN review_image ON review_image.review_id = review.id " +
+                "INNER JOIN lunch_box_review on lunch_box_review.id = review.id " +
+                "WHERE review.member_id = :memberId " +
+                "GROUP BY review.id, review.member_id " +
+                ") as data " +
+                "WHERE data.reviewCreatedAt BETWEEN :startDate AND :endDate " +
+                "ORDER BY data.reviewCreatedAt";
     }
 
     @PersistenceContext
@@ -62,6 +116,16 @@ public class ReviewProjectionRepository {
         Query query = entityManager.createNativeQuery(FIND_ALL_REVIEWS_BY_YEAR_AND_MONTH_QUERY, "ReviewAllList")
                 .setParameter("year", year)
                 .setParameter("month", month);
+
+        return query.getResultList();
+    }
+
+    public List<Projection.AllReviewDetailDTO> findAllReviewDetailBetween(Long memberId, LocalDateTime startDate, LocalDateTime endDate) {
+        Query query = entityManager.createNativeQuery(FIND_ALL_REVIEW_DETAIL_BETWEEN_DATE_QUERY, "AllReviewDetailListMapping")
+                .setParameter("separator", ImageSeparator.IMAGE_SEPARATOR)
+                .setParameter("memberId", memberId)
+                .setParameter("startDate", startDate)
+                .setParameter("endDate", endDate);
 
         return query.getResultList();
     }


### PR DESCRIPTION
기존의 달력 데이터 응답에 리뷰 상세 데이터를 포함하여 응답하는 기능을 구현한다.
- `GET` /api/reviews/detail/members?year=${year}&month=${month}
- #180 

### 쿼리
``` SQL
SELECT *
FROM (
SELECT 
review.selected_dishes as reviewTitle, 
restaurant_review.taste as reviewTaste, 
review.description as reviewDescription,
date_format(review.created_at, "%Y-%m-%d") as reviewCreatedAt,
restaurant.name as location,
GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images,
'restaurant' AS reviewType
FROM review
LEFT JOIN review_image ON review_image.review_id = review.id
INNER JOIN restaurant_review on restaurant_review.id = review.id
INNER JOIN restaurant on restaurant.id = restaurant_review.restaurant_id
WHERE review.member_id = :memberId
GROUP BY review.id, review.member_id
UNION
SELECT 
review.selected_dishes as reviewTitle, 
cafeteria_review.taste as reviewTaste, 
review.description as reviewDescription,
date_format(review.created_at, "%Y-%m-%d") as reviewCreatedAt,
building.name as location,
GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images,
'cafeteria' AS reviewType
FROM review
LEFT JOIN review_image ON review_image.review_id = review.id
INNER JOIN cafeteria_review on cafeteria_review.id = review.id
INNER JOIN building on building.id = cafeteria_review.building_id
WHERE review.member_id = :memberId
GROUP BY review.id, review.member_id
UNION
SELECT 
review.selected_dishes as reviewTitle, 
NULL as reviewTaste, 
review.description as reviewDescription,
date_format(review.created_at, "%Y-%m-%d") as reviewCreatedAt,
NULL as location,
GROUP_CONCAT(review_image.url SEPARATOR :separator) AS images,
'lunchBox' AS reviewType
FROM review
LEFT JOIN review_image ON review_image.review_id = review.id
INNER JOIN lunch_box_review on lunch_box_review.id = review.id
WHERE review.member_id = :memberId
GROUP BY review.id, review.member_id
) as data
WHERE data.reviewCreatedAt BETWEEN :startDate AND :endDate
ORDER BY data.reviewCreatedAt ;
```

resolved: #180 