### PR TITLE
리뷰 상세데이터를 포함한 오점완 달력 데이터 응답 기능 개선 완료

### DIFF
--- a/src/main/java/com/livable/server/entity/Review.java
+++ b/src/main/java/com/livable/server/entity/Review.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
         classes = @ConstructorResult(
                 targetClass = Projection.AllReviewDetailDTO.class,
                 columns = {
+                        @ColumnResult(name = "reviewId", type = Long.class),
                         @ColumnResult(name = "reviewTitle", type = String.class),
                         @ColumnResult(name = "reviewTaste", type = String.class),
                         @ColumnResult(name = "reviewDescription", type = String.class),

--- a/src/main/java/com/livable/server/review/dto/Projection.java
+++ b/src/main/java/com/livable/server/review/dto/Projection.java
@@ -55,6 +55,7 @@ public class Projection {
     @AllArgsConstructor
     public static class AllReviewDetailDTO {
 
+        private Long reviewId;
         private String reviewTitle;
         private Evaluation reviewTaste;
         private String reviewDescription;
@@ -63,8 +64,9 @@ public class Projection {
         private String images;
         private String reviewType;
 
-        public AllReviewDetailDTO(String reviewTitle, String reviewTaste, String reviewDescription, String reviewCreatedAt, String location, String images, String reviewType) {
+        public AllReviewDetailDTO(Long reviewId, String reviewTitle, String reviewTaste, String reviewDescription, String reviewCreatedAt, String location, String images, String reviewType) {
 
+            this.reviewId = reviewId;
             this.reviewTitle = reviewTitle;
             this.reviewTaste = Objects.isNull(reviewTaste) ? null : Evaluation.valueOf(reviewTaste);
             this.reviewDescription = reviewDescription;

--- a/src/main/java/com/livable/server/review/dto/ReviewResponse.java
+++ b/src/main/java/com/livable/server/review/dto/ReviewResponse.java
@@ -29,6 +29,7 @@ public class ReviewResponse {
     @Builder
     public static class DetailListDTO {
 
+        private Long reviewId;
         private String reviewTitle;
         private Evaluation reviewTaste;
         private String reviewDescription;
@@ -39,6 +40,7 @@ public class ReviewResponse {
 
         public static DetailListDTO valueOf(Projection.AllReviewDetailDTO detailDTO, ImageSeparator imageSeparator) {
             return DetailListDTO.builder()
+                    .reviewId(detailDTO.getReviewId())
                     .reviewTitle(detailDTO.getReviewTitle())
                     .reviewTaste(detailDTO.getReviewTaste())
                     .reviewDescription(detailDTO.getReviewDescription())

--- a/src/main/java/com/livable/server/review/repository/ReviewProjectionRepository.java
+++ b/src/main/java/com/livable/server/review/repository/ReviewProjectionRepository.java
@@ -62,6 +62,7 @@ public class ReviewProjectionRepository {
         FIND_ALL_REVIEW_DETAIL_BETWEEN_DATE_QUERY = "SELECT * " +
                 "FROM (" +
                 "SELECT " +
+                "review.id as reviewId, " +
                 "review.selected_dishes as reviewTitle, " +
                 "restaurant_review.taste as reviewTaste, " +
                 "review.description as reviewDescription, " +
@@ -77,6 +78,7 @@ public class ReviewProjectionRepository {
                 "GROUP BY review.id, review.member_id " +
                 "UNION " +
                 "SELECT " +
+                "review.id as reviewId, " +
                 "review.selected_dishes as reviewTitle, " +
                 "cafeteria_review.taste as reviewTaste, " +
                 "review.description as reviewDescription, " +
@@ -92,6 +94,7 @@ public class ReviewProjectionRepository {
                 "GROUP BY review.id, review.member_id " +
                 "UNION " +
                 "SELECT " +
+                "review.id as reviewId, " +
                 "review.selected_dishes as reviewTitle, " +
                 "NULL as reviewTaste, " +
                 "review.description as reviewDescription, " +


### PR DESCRIPTION
응답 데이터에 reviewId를 포함하도록 기능 개선
- #194 
- refactor https://github.com/livable-final/server/pull/181

resolved: #194 